### PR TITLE
[feature/frontend-31/Header] 헤더 로그인 비로그인 변경

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@testing-library/react": "^16.3.0",
         "@testing-library/user-event": "^13.5.0",
         "gsap": "^3.13.0",
+        "jwt-decode": "^4.0.0",
         "motion": "^12.23.12",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
@@ -11092,6 +11093,15 @@
       },
       "engines": {
         "node": ">=4.0"
+      }
+    },
+    "node_modules/jwt-decode": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
+      "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/keyv": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^13.5.0",
     "gsap": "^3.13.0",
+    "jwt-decode": "^4.0.0",
     "motion": "^12.23.12",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",

--- a/src/layout/user/Header.jsx
+++ b/src/layout/user/Header.jsx
@@ -1,85 +1,132 @@
 import { useNavigate } from "react-router-dom";
+import React, { useState, useEffect } from "react";
+import { FaUserCircle } from "react-icons/fa";
+import { jwtDecode } from "jwt-decode";
 
 function Header() {
   const navigate = useNavigate();
 
+  const [isLogin, setIsLogin] = useState(false);
+  const [userRole, setUserRole] = useState('투자자'); // 기본 역할을 '투자자'로 초기화
+
+  useEffect(() => {
+    const token = localStorage.getItem('jwtToken');
+    if (token) {
+      try {
+        const decodedToken = jwtDecode(token);
+        //decodedToken에 role 정보가 있을 경우 사용하고, 없으면 기본값으로 '투자자' 설정
+        setUserRole(decodedToken.role || '투자자');
+        setIsLogin(true); // 토큰이 유효하게 디코딩되면 로그인 상태로 설정
+      } catch (error) {
+        console.error("JWT 토큰 디코딩 오류:", error);
+        setIsLogin(false); // 토큰 디코딩 실패 시 로그인 상태 아님
+        localStorage.removeItem('jwtToken');
+      }
+    } else {
+      setIsLogin(false); // 토큰이 없으면 로그인 상태 아님
+    }
+  }, []);
+
+  //테스트를 위한 임시 함수
+  const toggleLoginStatus = () => {
+    if (isLogin) {
+      localStorage.removeItem('jwtToken');
+      setIsLogin(false);
+      setUserRole('투자자');
+    } else {
+      const testToken = JSON.stringify({ role: '투자자' }); // 이 부분은 실제 JWT 토큰 형식이 아님을 명심해주세요.
+      localStorage.setItem('jwtToken', testToken);
+      setIsLogin(true);
+      setUserRole('투자자'); //임시 로그인 시 역할 설정
+    }
+  };
+
+  const handleRoleToggle = () => {
+    setUserRole(prevRole => (prevRole === '투자자' ? '창작자' : '투자자'));
+  };
+
   return (
-    <div
-      className="
-            flex
-            justify-between
-            items-center
-            w-full
-            bg-white
-            py-2
-            px-[10%]
-        "
-    >
       <div
-        className="
-                flex
-                items-center
-                space-x-6
-            "
+          className="flex justify-between items-center w-full bg-white py-2 px-[10%]"
       >
-        <div>
-          <img
-            src="/assets/logo.png"
-            alt="로고"
-            className="w-20 h-10 min-h-1 min-w-1 hover:cursor-pointer"
-            onClick={() => navigate("/")}
-          />
-        </div>
-        <div>
+        <div className="flex items-center space-x-6">
+          <div>
+            <img
+                src="/assets/logo.png"
+                alt="로고"
+                className="w-20 h-10 min-h-1 min-w-1 hover:cursor-pointer"
+                onClick={() => navigate("/")}
+            />
+          </div>
+          <div>
           <span
-            className="hover:cursor-pointer"
-            onClick={() => navigate("/asset")}
+              className="hover:cursor-pointer"
+              onClick={() => navigate("/asset")}
           >
             자산 조회
           </span>
-        </div>{" "}
-        {/*주소 나중에 변경*/}
-        <div>
+          </div>
+          <div>
           <span
-            className="hover:cursor-pointer"
-            onClick={() => navigate("/investment")}
+              className="hover:cursor-pointer"
+              onClick={() => navigate("/investment")}
           >
             투자 상품
           </span>
-        </div>{" "}
-        {/*주소 나중에 변경*/}
-        <div>
+          </div>
+          <div>
           <span
-            className="hover:cursor-pointer"
-            onClick={() => navigate("/market")}
+              className="hover:cursor-pointer"
+              onClick={() => navigate("/market")}
           >
             토큰 거래
           </span>
-        </div>{" "}
-        {/*주소 나중에 변경*/}
-      </div>
-      <div
-        className="
-                flex
-                items-center
-                space-x-4
-            "
-      >
-        <div>
-          <button className="bg-red-500 px-5 py-3 rounded-full text-amber-50">
-            투자자
+          </div>
+        </div>
+        <div className="flex items-center space-x-4">
+          {/* 로그인 상태에 따른 버튼 표시 */}
+          {!isLogin ? (
+              <button
+                  className="bg-red-500 px-5 py-3 rounded-full text-amber-50"
+                  onClick={() => navigate("/login/1")}
+              >
+                로그인
+              </button>
+          ) : (
+              <div>
+                <button
+                    className={userRole === '투자자' ? "bg-red-500 px-5 py-3 rounded-full text-amber-50" : "bg-blue-600 px-5 py-3 rounded-full text-amber-50"}
+                    onClick={handleRoleToggle}
+                >
+                  {userRole}
+                </button>
+              </div>
+          )}
+
+          {!isLogin ? (
+              <div>
+                <FaUserCircle className="w-16 h-16 hover:cursor-pointer" onClick={() => navigate("/login/1")} />
+              </div>
+          ) : (
+              <div>
+                <img
+                    src={userRole === '투자자' ? "/assets/bull.png" : "/assets/pig.png"} // 예시: 역할에 따라 다른 아이콘
+                    alt={`${userRole} 아이콘`}
+                    className="w-16 h-16 hover:cursor-pointer"
+                    onClick={() => navigate("/my-profile")} // 사용자 프로필 페이지로 이동
+                />
+              </div>
+          )}
+
+          {/*테스트용 버튼 나중에 삭제할거임*/}
+          <button
+              className="bg-gray-400 px-5 py-3 rounded-full text-white"
+              onClick={toggleLoginStatus}
+          >
+            {isLogin ? '로그아웃 (테스트)' : '로그인 (테스트)'}
           </button>
         </div>
-        <div>
-          <img
-            src="/assets/bull.png"
-            alt="투자자"
-            className="w-16 h-16 hover:cursor-pointer"
-            onClick={() => navigate("/login/1")}
-          />
-        </div>
       </div>
-    </div>
   );
 }
 

--- a/src/layout/user/Header.jsx
+++ b/src/layout/user/Header.jsx
@@ -1,6 +1,6 @@
 import { useNavigate } from "react-router-dom";
 import React, { useState, useEffect } from "react";
-import { FaUserCircle } from "react-icons/fa";
+import { FaUser } from "react-icons/fa";
 import { jwtDecode } from "jwt-decode";
 
 function Header() {
@@ -105,14 +105,14 @@ function Header() {
 
           {!isLogin ? (
               <div>
-                <FaUserCircle className="w-16 h-16 hover:cursor-pointer" onClick={() => navigate("/login/1")} />
+                <FaUser className="w-10 h-10 hover:cursor-pointer" onClick={() => navigate("/login/1")} />
               </div>
           ) : (
               <div>
                 <img
                     src={userRole === '투자자' ? "/assets/bull.png" : "/assets/pig.png"} // 예시: 역할에 따라 다른 아이콘
                     alt={`${userRole} 아이콘`}
-                    className="w-16 h-16 hover:cursor-pointer"
+                    className="w-12 h-12 hover:cursor-pointer"
                     onClick={() => navigate("/my-profile")} // 사용자 프로필 페이지로 이동
                 />
               </div>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,6 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
-  content: ["./src/**/*.{js, jsx, ts, tsxcd}"],
+  content: ["./src/**/*.{js,jsx,ts,tsx}"],
 
   theme: {
     extend: {},


### PR DESCRIPTION
## 이슈
- Resolve #29 #30 


## 📁 작업 파일
header.jsx


## 📝작업 내용
- 내용
  비 로그인 시 로그인 버튼 유지
  로그인 시 투자자 창작자로 변경 가능하게 변경


## 🖼️작업 완료 이미지 (완성된 페이지 전과 후 비교 및 코드 사진)
<img width="1347" height="60" alt="image" src="https://github.com/user-attachments/assets/cd48d32a-b2bc-481a-b0fb-b3cd375275bc" />
<img width="193" height="71" alt="image" src="https://github.com/user-attachments/assets/9c2c4d2f-d486-44f1-a10b-bed9ef7e22c7" />
<img width="193" height="71" alt="image" src="https://github.com/user-attachments/assets/3a085792-90c4-4c89-a704-9cb401adb2bb" />



## 🚨수정 필요 내용
- 나중에 로그인 테스트 버튼을 제거해야함
- 나중에 back이랑 연결 필요
