### PR TITLE
[feature/frontend-38/assetpage] Asset 화면 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "react-icons": "^5.5.0",
         "react-router-dom": "^7.7.1",
         "react-scripts": "5.0.1",
+        "react-toastify": "^11.0.5",
         "three": "^0.179.1",
         "web-vitals": "^2.1.4"
       },
@@ -5676,6 +5677,15 @@
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
         "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/co": {
@@ -14193,6 +14203,19 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-toastify": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-11.0.5.tgz",
+      "integrity": "sha512-EpqHBGvnSTtHYhCPLxML05NLY2ZX0JURbAdNYa6BUkk+amz4wbKBQvoKQAB0ardvSarUBuY4Q4s1sluAzZwkmA==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19",
+        "react-dom": "^18 || ^19"
       }
     },
     "node_modules/read-cache": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "react-icons": "^5.5.0",
     "react-router-dom": "^7.7.1",
     "react-scripts": "5.0.1",
+    "react-toastify": "^11.0.5",
     "three": "^0.179.1",
     "web-vitals": "^2.1.4"
   },

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,11 +9,15 @@ import InvestmentListPage from "./pages/investment/investmentList.jsx";
 import InvestmentDetail from "./pages/investment/investmentDetail.jsx";
 import Market from "./pages/market/Market.jsx";
 import MarketDetail from "./pages/market/MarketDetail.jsx";
+import { ToastContainer } from "react-toastify";
+import Asset from "./pages/asset/Asset.jsx";
 
 function App() {
   return (
     <BrowserRouter>
       <div className="flex flex-col">
+        {/* 전역 토스트 컨테이너 */}
+        <ToastContainer position="bottom-right" />
         <ScrollToTop />
         <Routes>
           {/*헤더, 푸터 고정 설정*/}
@@ -28,6 +32,9 @@ function App() {
             {/*Market*/}
             <Route path="/market" element={<Market />} />
             <Route path="/market/:id" element={<MarketDetail />} />
+
+            {/*Asset*/}
+            <Route path="/asset" element={<Asset />} />
           </Route>
 
           {/*관리자 페이지 헤더*/}

--- a/src/component/button.jsx
+++ b/src/component/button.jsx
@@ -1,13 +1,13 @@
-import React from 'react';
+import React from "react";
 
-function button(){
-    return(
-        <div>
-            <button className="p-2 bg-red-500 rounded-xl text-amber-50 mt-1 h-14 w-36">
-                나는 버튼이예요
-            </button>
-        </div>
-    )
+function button() {
+  return (
+    <div>
+      <button className="p-2 bg-red-500 rounded-xl text-amber-50 mt-1 h-14 w-36">
+        나는 버튼이예요
+      </button>
+    </div>
+  );
 }
 
 export default button;

--- a/src/pages/asset/Asset.jsx
+++ b/src/pages/asset/Asset.jsx
@@ -1,0 +1,25 @@
+import { useState } from "react";
+import AssetHome from "./AssetHome";
+import MyAsset from "./MyAsset";
+
+function Asset() {
+  const [showAssetHome, setShowAssetHome] = useState(true);
+
+  const toggleComponent = () => {
+    setShowAssetHome((prev) => !prev);
+  };
+
+  return (
+    <div>
+      <button
+        onClick={toggleComponent}
+        className="bg-blue-500 text-white px-4 py-2 rounded"
+      >
+        TOGGLE
+      </button>
+      {showAssetHome ? <AssetHome /> : <MyAsset />}
+    </div>
+  );
+}
+
+export default Asset;

--- a/src/pages/asset/AssetHome.jsx
+++ b/src/pages/asset/AssetHome.jsx
@@ -1,0 +1,52 @@
+import CardSwap, { Card } from "./CardSwap";
+
+function AssetHome() {
+  return (
+    <div className="relative rounded-lg h-screen flex items-center justify-center">
+      {/* CardSwap 컴포넌트 */}
+      <div className="flex-1">
+        <CardSwap
+          cardDistance={40}
+          verticalDistance={20}
+          delay={3000}
+          pauseOnHover={false}
+        >
+          <Card altText="Card 1">
+            <img
+              src="/assets/startingpage_1.jpg"
+              alt="Card 1"
+              className="w-full h-full object-cover rounded-xl"
+            />
+          </Card>
+          <Card>
+            <img
+              src="/assets/startingpage_2.jpg"
+              alt="Card 2"
+              className="w-full h-full object-cover rounded-xl"
+            />
+          </Card>
+          <Card>
+            <img
+              src="/assets/startingpage_3.jpg"
+              alt="Card 3"
+              className="w-full h-full object-cover rounded-xl"
+            />
+          </Card>
+        </CardSwap>
+      </div>
+
+      {/* 텍스트 영역 */}
+      <div className="flex-2 text-center">
+        <h1 className="text-4xl font-bold mb-4">조각투자가 처음이신가요?</h1>
+        <p className="text-lg text-gray-500 mb-6">
+          쪼개몰에서 쉽고 간단하고 안전하게 시작하세요.
+        </p>
+        <button className="bg-red-500 text-white px-6 py-3 rounded-lg font-bold">
+          계좌 생성하기
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export default AssetHome;

--- a/src/pages/asset/CardSwap.jsx
+++ b/src/pages/asset/CardSwap.jsx
@@ -1,0 +1,220 @@
+import React, {
+  Children,
+  cloneElement,
+  forwardRef,
+  isValidElement,
+  useEffect,
+  useMemo,
+  useRef,
+} from "react";
+import gsap from "gsap";
+
+export const Card = forwardRef(
+  ({ customClass, imageSrc, altText, ...rest }, ref) => (
+    <div
+      ref={ref}
+      {...rest}
+      className={`absolute rounded-xl border border-white [transform-style:preserve-3d] [will-change:transform] [backface-visibility:hidden] ${
+        customClass ?? ""
+      } ${rest.className ?? ""}`.trim()}
+    >
+      {imageSrc && (
+        <img
+          src={imageSrc}
+          alt={altText || "Card Image"}
+          className="w-full h-full object-cover rounded-xl"
+        />
+      )}
+      {rest.children}
+    </div>
+  )
+);
+Card.displayName = "Card";
+
+const makeSlot = (i, distX, distY, total) => ({
+  x: i * distX,
+  y: -i * distY,
+  z: -i * distX * 1.5,
+  zIndex: total - i,
+});
+
+const placeNow = (el, slot, skew) =>
+  gsap.set(el, {
+    x: slot.x,
+    y: slot.y,
+    z: slot.z,
+    xPercent: -50,
+    yPercent: -50,
+    skewY: skew,
+    transformOrigin: "center center",
+    zIndex: slot.zIndex,
+    force3D: true,
+  });
+
+const CardSwap = ({
+  width = 640,
+  height = 460,
+  cardDistance = 60,
+  verticalDistance = 70,
+  delay = 5000,
+  pauseOnHover = false,
+  onCardClick,
+  skewAmount = 6,
+  easing = "elastic",
+  children,
+}) => {
+  const config =
+    easing === "elastic"
+      ? {
+          ease: "elastic.out(0.6,0.9)",
+          durDrop: 2,
+          durMove: 2,
+          durReturn: 2,
+          promoteOverlap: 0.9,
+          returnDelay: 0.05,
+        }
+      : {
+          ease: "power1.inOut",
+          durDrop: 0.8,
+          durMove: 0.8,
+          durReturn: 0.8,
+          promoteOverlap: 0.45,
+          returnDelay: 0.2,
+        };
+
+  const childArr = useMemo(() => Children.toArray(children), [children]);
+  const refs = useMemo(
+    () => childArr.map(() => React.createRef()),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [childArr.length]
+  );
+
+  const order = useRef(Array.from({ length: childArr.length }, (_, i) => i));
+
+  const tlRef = useRef(null);
+  const intervalRef = useRef();
+  const container = useRef(null);
+
+  useEffect(() => {
+    const total = refs.length;
+    refs.forEach((r, i) =>
+      placeNow(
+        r.current,
+        makeSlot(i, cardDistance, verticalDistance, total),
+        skewAmount
+      )
+    );
+
+    const swap = () => {
+      if (order.current.length < 2) return;
+
+      const [front, ...rest] = order.current;
+      const elFront = refs[front].current;
+      const tl = gsap.timeline();
+      tlRef.current = tl;
+
+      tl.to(elFront, {
+        y: "+=500",
+        duration: config.durDrop,
+        ease: config.ease,
+      });
+
+      tl.addLabel("promote", `-=${config.durDrop * config.promoteOverlap}`);
+      rest.forEach((idx, i) => {
+        const el = refs[idx].current;
+        const slot = makeSlot(i, cardDistance, verticalDistance, refs.length);
+        tl.set(el, { zIndex: slot.zIndex }, "promote");
+        tl.to(
+          el,
+          {
+            x: slot.x,
+            y: slot.y,
+            z: slot.z,
+            duration: config.durMove,
+            ease: config.ease,
+          },
+          `promote+=${i * 0.15}`
+        );
+      });
+
+      const backSlot = makeSlot(
+        refs.length - 1,
+        cardDistance,
+        verticalDistance,
+        refs.length
+      );
+      tl.addLabel("return", `promote+=${config.durMove * config.returnDelay}`);
+      tl.call(
+        () => {
+          gsap.set(elFront, { zIndex: backSlot.zIndex });
+        },
+        undefined,
+        "return"
+      );
+      tl.set(elFront, { x: backSlot.x, z: backSlot.z }, "return");
+      tl.to(
+        elFront,
+        {
+          y: backSlot.y,
+          duration: config.durReturn,
+          ease: config.ease,
+        },
+        "return"
+      );
+
+      tl.call(() => {
+        order.current = [...rest, front];
+      });
+    };
+
+    swap();
+    intervalRef.current = window.setInterval(swap, delay);
+
+    if (pauseOnHover) {
+      const node = container.current;
+      const pause = () => {
+        tlRef.current?.pause();
+        clearInterval(intervalRef.current);
+      };
+      const resume = () => {
+        tlRef.current?.play();
+        intervalRef.current = window.setInterval(swap, delay);
+      };
+      node.addEventListener("mouseenter", pause);
+      node.addEventListener("mouseleave", resume);
+      return () => {
+        node.removeEventListener("mouseenter", pause);
+        node.removeEventListener("mouseleave", resume);
+        clearInterval(intervalRef.current);
+      };
+    }
+    return () => clearInterval(intervalRef.current);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [cardDistance, verticalDistance, delay, pauseOnHover, skewAmount, easing]);
+
+  const rendered = childArr.map((child, i) =>
+    isValidElement(child)
+      ? cloneElement(child, {
+          key: i,
+          ref: refs[i],
+          style: { width, height, ...(child.props.style ?? {}) },
+          onClick: (e) => {
+            child.props.onClick?.(e);
+            onCardClick?.(i);
+          },
+        })
+      : child
+  );
+
+  return (
+    <div
+      ref={container}
+      className="relative top-32 left-80 transform translate-x-[5%] translate-y-[20%] origin-bottom-right perspective-[900px] overflow-visible max-[768px]:translate-x-[25%] max-[768px]:translate-y-[25%] max-[768px]:scale-[0.75] max-[480px]:translate-x-[25%] max-[480px]:translate-y-[25%] max-[480px]:scale-[0.55]"
+      style={{ width, height }}
+    >
+      {rendered}
+    </div>
+  );
+};
+
+export default CardSwap;

--- a/src/pages/asset/MyAsset.jsx
+++ b/src/pages/asset/MyAsset.jsx
@@ -1,0 +1,530 @@
+import { useState } from "react";
+import { FaRegCopy } from "react-icons/fa";
+import AssetDepositModal from "./modals/AssetDepositModal";
+import AssetWithdrawModal from "./modals/AssetWithdrawModal";
+import { toast } from "react-toastify";
+import AssetCheckModal from "./modals/AssetCheckModal";
+
+function MyAsset() {
+  const transactions = [
+    {
+      date: "07/15/2024",
+      amount: "+500.00",
+      time: "10:30 AM",
+      balance: "$12,500.00",
+      type: "입금",
+    },
+    {
+      date: "07/10/2024",
+      amount: "+1,000.00",
+      time: "02:45 PM",
+      balance: "$14,500.00",
+      type: "입금",
+    },
+    {
+      date: "07/05/2024",
+      amount: "+2,000.00",
+      time: "09:15 AM",
+      balance: "$13,500.00",
+      type: "입금",
+    },
+    {
+      date: "06/28/2024",
+      amount: "+800.00",
+      time: "04:00 PM",
+      balance: "$11,500.00",
+      type: "입금",
+    },
+    {
+      date: "06/20/2024",
+      amount: "-1,500.00",
+      time: "11:00 AM",
+      balance: "$12,300.00",
+      type: "출금",
+    },
+    {
+      date: "07/15/2024",
+      amount: "+500.00",
+      time: "10:30 AM",
+      balance: "$12,500.00",
+      type: "입금",
+    },
+    {
+      date: "07/15/2024",
+      amount: "+500.00",
+      time: "10:30 AM",
+      balance: "$12,500.00",
+      type: "입금",
+    },
+    {
+      date: "07/15/2024",
+      amount: "+500.00",
+      time: "10:30 AM",
+      balance: "$12,500.00",
+      type: "입금",
+    },
+    {
+      date: "07/15/2024",
+      amount: "+500.00",
+      time: "10:30 AM",
+      balance: "$12,500.00",
+      type: "입금",
+    },
+    {
+      date: "07/15/2024",
+      amount: "+500.00",
+      time: "10:30 AM",
+      balance: "$12,500.00",
+      type: "입금",
+    },
+    {
+      date: "07/15/2024",
+      amount: "+500.00",
+      time: "10:30 AM",
+      balance: "$12,500.00",
+      type: "입금",
+    },
+    {
+      date: "07/15/2024",
+      amount: "+500.00",
+      time: "10:30 AM",
+      balance: "$12,500.00",
+      type: "입금",
+    },
+    {
+      date: "07/15/2024",
+      amount: "+500.00",
+      time: "10:30 AM",
+      balance: "$12,500.00",
+      type: "입금",
+    },
+    {
+      date: "07/15/2024",
+      amount: "+500.00",
+      time: "10:30 AM",
+      balance: "$12,500.00",
+      type: "입금",
+    },
+    {
+      date: "07/15/2024",
+      amount: "+500.00",
+      time: "10:30 AM",
+      balance: "$12,500.00",
+      type: "입금",
+    },
+    {
+      date: "07/15/2024",
+      amount: "+500.00",
+      time: "10:30 AM",
+      balance: "$12,500.00",
+      type: "입금",
+    },
+  ];
+  const tokenDetails = [
+    {
+      projectName: "감만유",
+      amount: "30",
+      time: "02:45 PM",
+      date: "07/10/2024",
+      tokenNumber: "rnalsdhkswjsqkhajcdjdl",
+    },
+    {
+      projectName: "감만유",
+      amount: "30",
+      time: "02:45 PM",
+      date: "07/10/2024",
+      tokenNumber: "rnalsdhkswjsqkhajcdjdl",
+    },
+    {
+      projectName: "감만유",
+      amount: "30",
+      time: "02:45 PM",
+      date: "07/10/2024",
+      tokenNumber: "rnalsdhkswjsqkhajcdjdl",
+    },
+    {
+      projectName: "감만유",
+      amount: "30",
+      time: "02:45 PM",
+      date: "07/10/2024",
+      tokenNumber: "rnalsdhkswjsqkhajcdjdl",
+    },
+    {
+      projectName: "감만유",
+      amount: "30",
+      time: "02:45 PM",
+      date: "07/10/2024",
+      tokenNumber: "rnalsdhkswjsqkhajcdjdl",
+    },
+    {
+      projectName: "감만유",
+      amount: "30",
+      time: "02:45 PM",
+      date: "07/10/2024",
+      tokenNumber: "rnalsdhkswjsqkhajcdjdl",
+    },
+
+    {
+      projectName: "케로로 중사",
+      amount: "2,000",
+      time: "09:15 AM",
+      date: "07/05/2024",
+      tokenNumber: "gywnsdlakfantlgkwlak!",
+    },
+    {
+      projectName: "영구와 땡칠이",
+      amount: "80",
+      time: "04:00 PM",
+      date: "06/28/2024",
+      tokenNumber: "alsdlmsgodhqrgkekgpgpg",
+    },
+    {
+      projectName: "뽀로로와 친구들",
+      amount: "30",
+      time: "11:00 AM",
+      date: "06/20/2024",
+      tokenNumber: "wnsghsmsdhkswjsQkfro",
+    },
+  ];
+  const tokenMarkets = [
+    {
+      projectName: "감만유",
+      amount: "+30",
+      time: "02:45 PM",
+      date: "07/10/2024",
+      tokenNumber: "rnalsdhkswjsqkhajcdjdl",
+    },
+    {
+      projectName: "감만유",
+      amount: "+30",
+      time: "02:45 PM",
+      date: "07/10/2024",
+      tokenNumber: "rnalsdhkswjsqkhajcdjdl",
+    },
+    {
+      projectName: "감만유",
+      amount: "-30",
+      time: "02:45 PM",
+      date: "07/10/2024",
+      tokenNumber: "rnalsdhkswjsqkhajcdjdl",
+    },
+    {
+      projectName: "감만유",
+      amount: "-30",
+      time: "02:45 PM",
+      date: "07/10/2024",
+      tokenNumber: "rnalsdhkswjsqkhajcdjdl",
+    },
+    {
+      projectName: "감만유",
+      amount: "-30",
+      time: "02:45 PM",
+      date: "07/10/2024",
+      tokenNumber: "rnalsdhkswjsqkhajcdjdl",
+    },
+    {
+      projectName: "감만유",
+      amount: "+30",
+      time: "02:45 PM",
+      date: "07/10/2024",
+      tokenNumber: "rnalsdhkswjsqkhajcdjdl",
+    },
+
+    {
+      projectName: "케로로 중사",
+      amount: "-2,000",
+      time: "09:15 AM",
+      date: "07/05/2024",
+      tokenNumber: "gywnsdlakfantlgkwlak!",
+    },
+    {
+      projectName: "영구와 땡칠이",
+      amount: "+80",
+      time: "04:00 PM",
+      date: "06/28/2024",
+      tokenNumber: "alsdlmsgodhqrgkekgpgpg",
+    },
+    {
+      projectName: "뽀로로와 친구들",
+      amount: "+30",
+      time: "11:00 AM",
+      date: "06/20/2024",
+      tokenNumber: "wnsghsmsdhkswjsQkfro",
+    },
+  ];
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [modalType, setModalType] = useState(""); // "입금" 또는 "출금"
+  const [activeTab, setActiveTab] = useState("계좌 정보");
+
+  const [isCheckOpen, setIsCheckOpen] = useState(false);
+  const [depositAmount, setDepositAmount] = useState(null);
+  const [withdrawAmount, setWithdrawAmount] = useState(null);
+
+  const openModal = (type) => {
+    setModalType(type);
+    setIsModalOpen(true);
+  };
+
+  const closeModal = () => {
+    setIsModalOpen(false);
+  };
+
+  const handleDepositConfirm = (amount) => {
+    setDepositAmount(amount); // 입금 출금 금액
+    setIsCheckOpen(true); // 확인 모달 열기
+  };
+  const handleWithdrawConfirm = (amount) => {
+    setWithdrawAmount(amount);
+    setIsCheckOpen(true);
+  };
+
+  // 계좌번호, 지갑번호 복사 기능
+  const copyToClipboard = (text) => {
+    navigator.clipboard.writeText(text);
+    console.log(`Copied to clipboard: ${text}`);
+  };
+
+  const notify = () => toast("Copied to clipboard!");
+
+  return (
+    <div className="mt-8 mb-16">
+      <h1 className="text-3xl font-bold mb-2">자산 조회</h1>
+      <p className="text-gray-500 mb-6">
+        View detailed information about your account.
+      </p>
+
+      <div className="flex items-center gap-12 mb-6">
+        <div className="flex-col items-center gap-2">
+          <span className="text-gray-500 text-sm">계좌 번호</span>
+          <div className="flex items-center gap-2">
+            <p className="text-md">1234567890</p>
+            <button
+              onClick={() => {
+                copyToClipboard("1234567890");
+                notify();
+              }}
+              className="text-gray-400 hover:text-gray-600"
+            >
+              <FaRegCopy />
+            </button>
+          </div>
+        </div>
+        <div className="flex-col items-center gap-2">
+          <span className="text-gray-500 text-sm">지갑 번호</span>
+          <div className="flex items-center gap-2">
+            <p className="text-md">9876543210</p>
+            <button
+              onClick={() => {
+                copyToClipboard("9876543210");
+                notify();
+              }}
+              className="text-gray-400 hover:text-gray-600"
+            >
+              <FaRegCopy />
+            </button>
+          </div>
+        </div>
+      </div>
+
+      {/* 탭 메뉴 */}
+      <div className="flex border-b mb-6">
+        <button
+          className={`px-4 py-2 font-bold ${
+            activeTab === "계좌 정보"
+              ? "text-red-500 border-b-2 border-red-500"
+              : "text-gray-400"
+          }`}
+          onClick={() => setActiveTab("계좌 정보")}
+        >
+          계좌 정보
+        </button>
+        <button
+          className={`px-4 py-2 font-bold ${
+            activeTab === "지갑 정보"
+              ? "text-red-500 border-b-2 border-red-500"
+              : "text-gray-400"
+          }`}
+          onClick={() => setActiveTab("지갑 정보")}
+        >
+          지갑 정보
+        </button>
+      </div>
+
+      {/* 계좌 정보 */}
+      {activeTab === "계좌 정보" && (
+        <div>
+          <div className="border rounded-lg p-6 px-16 mb-6">
+            <div className="flex justify-around items-center mb-4">
+              <div className="text-center">
+                <span className="text-gray-500 text-sm">이번달 입금</span>
+                <p className="text-3xl font-bold">12,000원</p>
+              </div>
+              <span className="text-gray-300">|</span>
+              <div className="text-center">
+                <span className="text-gray-500 text-sm">잔액</span>
+                <p className="text-3xl font-bold">1,412,413,000원</p>
+              </div>
+              <span className="text-gray-300">|</span>
+              <div className="text-center">
+                <span className="text-gray-500 text-sm">이번달 출금</span>
+                <p className="text-3xl font-bold">12,000원</p>
+              </div>
+            </div>
+            <div className="mt-12 w-full flex justify-center gap-16">
+              <button
+                className="w-52 bg-red-500 text-white font-bold rounded-lg px-8 py-3"
+                onClick={() => openModal("입금")}
+              >
+                입금
+              </button>
+              <button
+                className="w-52 bg-red-100 text-red-500 font-bold rounded-lg px-8 py-3"
+                onClick={() => openModal("출금")}
+              >
+                출금
+              </button>
+            </div>
+            {/* Modal */}
+            {isModalOpen && (
+              <>
+                {/* Modal */}
+                <>
+                  {modalType === "입금" && (
+                    <AssetDepositModal
+                      isOpen={isModalOpen}
+                      onClose={closeModal}
+                      onConfirm={handleDepositConfirm}
+                    />
+                  )}
+                  {modalType === "출금" && (
+                    <AssetWithdrawModal
+                      isOpen={isModalOpen}
+                      onClose={closeModal}
+                      onConfirm={handleWithdrawConfirm}
+                    />
+                  )}
+                  <AssetCheckModal
+                    isOpen={isCheckOpen}
+                    onClose={() => setIsCheckOpen(false)}
+                    onConfirmAll={() => {
+                      setIsCheckOpen(false); // 체크 모달 닫기
+                      setIsModalOpen(false); // 입금/출금 모달도 함께 닫기
+                    }}
+                    amount={
+                      modalType === "입금" ? depositAmount : withdrawAmount
+                    }
+                    type={modalType}
+                  />
+                </>
+              </>
+            )}
+          </div>
+
+          {/* 거래 기록 */}
+          <h2 className="text-xl font-bold mb-4 mt-12">거래 기록</h2>
+          <div className="border-gray-200 border rounded-lg p-6 overflow-x-auto">
+            <table className="w-full text-sm rounded-lg">
+              <thead className="border-b border-gray-200">
+                <tr className="text-gray-500 text-left">
+                  <th className="py-2 font-normal w-1/5">Date</th>
+                  <th className="font-normal w-1/5">Amount</th>
+                  <th className="font-normal w-1/5">Time</th>
+                  <th className="font-normal w-1/5">Resulting Balance</th>
+                  <th className="font-normal w-1/5">Type</th>
+                </tr>
+              </thead>
+              <tbody>
+                {transactions.map((transaction, index) => (
+                  <tr key={index} className="border-b border-gray-100">
+                    <td className="py-4 w-1/5">{transaction.date}</td>
+                    <td
+                      className={`font-bold w-1/5 ${
+                        transaction.amount.startsWith("+")
+                          ? "text-red-500"
+                          : "text-blue-500"
+                      }`}
+                    >
+                      {transaction.amount}
+                    </td>
+                    <td className="w-1/5">{transaction.time}</td>
+                    <td className="w-1/5">{transaction.balance}</td>
+                    <td className="text-red-500 w-1/5">{transaction.type}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+
+      {/* 지갑 정보 */}
+      {activeTab === "지갑 정보" && (
+        <div>
+          {/* 토큰 내역 */}
+          <h2 className="text-xl font-bold mb-4">토큰 내역</h2>
+          <div className="border-gray-200 border rounded-lg p-6 overflow-x-auto mb-6">
+            <table className="w-full text-sm rounded-lg">
+              <thead className="border-b border-gray-200">
+                <tr className="text-gray-500 text-left">
+                  <th className="py-2 font-normal w-1/5">Project Name</th>
+                  <th className="font-normal w-1/5">Amount</th>
+                  <th className="font-normal w-1/5">Time</th>
+                  <th className="font-normal w-1/5">Date</th>
+                  <th className="font-normal w-1/5">Token Number</th>
+                </tr>
+              </thead>
+              <tbody>
+                {tokenDetails.map((token, index) => (
+                  <tr key={index} className="border-b border-gray-100">
+                    <td className="py-4 w-1/5">{token.projectName}</td>
+                    <td className="w-1/5">{token.amount}</td>
+                    <td className="w-1/5">{token.time}</td>
+                    <td className="w-1/5">{token.date}</td>
+                    <td className="text-blue-500 w-1/5">{token.tokenNumber}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          {/* 토큰 거래 기록 */}
+          <h2 className="text-xl font-bold mb-4">토큰 거래 기록</h2>
+          <div className="border-gray-200 border rounded-lg p-6 overflow-x-auto mb-6">
+            <table className="w-full text-sm rounded-lg">
+              <thead className="border-b border-gray-200">
+                <tr className="text-gray-500 text-left">
+                  <th className="py-2 font-normal w-1/5">Project Name</th>
+                  <th className="font-normal w-1/5">Amount</th>
+                  <th className="font-normal w-1/5">Time</th>
+                  <th className="font-normal w-1/5">Date</th>
+                  <th className="font-normal w-1/5">Token Number</th>
+                </tr>
+              </thead>
+              <tbody>
+                {tokenMarkets.map((token, index) => (
+                  <tr key={index} className="border-b border-gray-100">
+                    <td className="py-4 w-1/5">{token.projectName}</td>
+                    <td
+                      className={`font-bold w-1/5 ${
+                        token.amount.startsWith("+")
+                          ? "text-red-500"
+                          : "text-blue-500"
+                      }`}
+                    >
+                      {token.amount}
+                    </td>
+                    <td className="w-1/5">{token.time}</td>
+                    <td className="w-1/5">{token.date}</td>
+                    <td className="text-blue-500 w-1/5">{token.tokenNumber}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default MyAsset;

--- a/src/pages/asset/modals/AssetCheckModal.jsx
+++ b/src/pages/asset/modals/AssetCheckModal.jsx
@@ -1,0 +1,65 @@
+import useScrollLock from "../../../component/ScrollLock";
+import { toast } from "react-toastify";
+
+function AssetCheckModal({
+  isOpen,
+  onClose,
+  onConfirmAll,
+  amount,
+  type = "입금",
+}) {
+  useScrollLock(isOpen);
+  if (!isOpen) return null;
+
+  const handleOverlayClick = (e) => {
+    if (e.target === e.currentTarget) onClose();
+  };
+
+  const handleConfirm = () => {
+    // 부모에서 모든 모달을 닫도록 위임
+    onConfirmAll?.();
+    toast.success(`${type}이 완료되었습니다.`, {
+      style: { backgroundColor: "#fff", color: "#111" },
+      progressStyle: { backgroundColor: "#ef4444" },
+    });
+  };
+
+  return (
+    <div
+      className="fixed inset-0 bg-gray-600 bg-opacity-50 flex justify-center items-center z-50"
+      onClick={handleOverlayClick}
+    >
+      <div className="bg-white p-8 rounded-lg shadow-lg w-full max-w-md relative">
+        <button
+          onClick={onClose}
+          className="absolute top-4 right-4 text-gray-500 hover:text-gray-700 text-3xl font-bold"
+        >
+          &times;
+        </button>
+        <h2 className="text-2xl font-bold text-center mb-6">{type} 확인</h2>
+        <p className="text-center text-gray-700 mb-8">
+          {type} 금액:{" "}
+          <span className="font-bold text-red-600">
+            {amount?.toLocaleString()}원
+          </span>
+        </p>
+        <div className="flex justify-center gap-3">
+          <button
+            onClick={onClose}
+            className="bg-gray-300 text-gray-800 py-2 px-4 rounded-md hover:bg-gray-400 font-semibold"
+          >
+            취소
+          </button>
+          <button
+            onClick={handleConfirm}
+            className="bg-red-500 text-white py-2 px-4 rounded-md hover:bg-red-600 font-semibold"
+          >
+            확인
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default AssetCheckModal;

--- a/src/pages/asset/modals/AssetDepositModal.jsx
+++ b/src/pages/asset/modals/AssetDepositModal.jsx
@@ -1,0 +1,96 @@
+import { useState } from "react";
+import useScrollLock from "../../../component/ScrollLock";
+import { CiCircleQuestion } from "react-icons/ci";
+
+function AssetDepositModal({ isOpen, onClose, onConfirm }) {
+  useScrollLock(isOpen);
+
+  // 화면에 보이는 값(콤마 포함)
+  const [priceStr, setPriceStr] = useState("");
+
+  if (!isOpen) return null;
+
+  const handleOverlayClick = (e) => {
+    if (e.target === e.currentTarget) onClose();
+  };
+
+  const formatNumber = (digits) => digits.replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+
+  const handlePriceChange = (e) => {
+    // 숫자만 남기고 나머지 제거
+    const onlyDigits = e.target.value.replace(/[^\d]/g, "");
+    // 빈값은 그대로 빈문자열 유지
+    if (onlyDigits === "") {
+      setPriceStr("");
+      return;
+    }
+    // 콤마 포맷 적용
+    setPriceStr(formatNumber(onlyDigits));
+  };
+
+  const handleSubmit = () => {
+    // 콤마 제거 후 숫자로 변환
+    const amount = Number(priceStr.replaceAll(",", ""));
+    if (!amount || amount <= 0) return;
+    onConfirm(amount); // 부모로 숫자 전달
+  };
+
+  return (
+    <div
+      className="fixed inset-0 bg-gray-600 bg-opacity-50 flex justify-center items-center z-50"
+      onClick={handleOverlayClick}
+    >
+      <div className="bg-white p-8 rounded-lg shadow-lg w-full max-w-lg relative animate-fade-in">
+        <button
+          onClick={onClose}
+          className="absolute top-4 right-4 text-gray-500 hover:text-gray-700 text-3xl font-bold"
+        >
+          &times;
+        </button>
+
+        <h1 className="text-3xl font-bold mb-1 text-center">입금하기</h1>
+        <h3 className="text-md text-gray-500 mb-6 text-center">
+          (가격단위:원)
+        </h3>
+        <hr className="mb-6" />
+
+        <div className="mb-4">
+          <div className="flex justify-between items-center">
+            <div className="flex gap-2 items-center text-gray-600">
+              <span>실명 계좌</span>
+              <CiCircleQuestion />
+            </div>
+            <span className="text-gray-500">100012641093</span>
+          </div>
+
+          <input
+            type="text" // number 대신 text로 변경(콤마 표시용)
+            inputMode="numeric" // 모바일에서 숫자 키패드
+            pattern="[0-9]*" // 숫자만
+            value={priceStr}
+            onChange={handlePriceChange}
+            className="mt-8 w-full border rounded-lg px-4 py-2"
+            placeholder="입금하실 금액을 입력해주세요"
+          />
+        </div>
+
+        <div className="flex justify-center space-x-3 mt-6">
+          <button
+            onClick={onClose}
+            className="bg-gray-300 text-gray-800 py-2 px-4 rounded-md hover:bg-gray-400 transition-colors font-semibold"
+          >
+            취소
+          </button>
+          <button
+            onClick={handleSubmit}
+            className="bg-red-300 text-white py-2 px-4 rounded-md hover:bg-red-500 transition-colors font-semibold"
+          >
+            입금신청
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default AssetDepositModal;

--- a/src/pages/asset/modals/AssetWithdrawModal.jsx
+++ b/src/pages/asset/modals/AssetWithdrawModal.jsx
@@ -1,0 +1,103 @@
+import { useState } from "react";
+import useScrollLock from "../../../component/ScrollLock";
+import { CiCircleQuestion } from "react-icons/ci";
+
+function AssetWithdrawModal({ isOpen, onClose, onConfirm }) {
+  useScrollLock(isOpen);
+
+  // ...existing code...
+  // 콤마 포함 문자열 상태로 관리
+  const [priceStr, setPriceStr] = useState("");
+
+  if (!isOpen) return null;
+
+  const handleOverlayClick = (e) => {
+    if (e.target === e.currentTarget) onClose();
+  };
+
+  // 3자리 콤마 포맷터
+  const formatNumber = (digits) => digits.replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+
+  // 숫자만 유지하면서 콤마 적용
+  const handlePriceChange = (e) => {
+    const onlyDigits = e.target.value.replace(/[^\d]/g, "");
+    if (onlyDigits === "") {
+      setPriceStr("");
+      return;
+    }
+    setPriceStr(formatNumber(onlyDigits));
+  };
+
+  // 제출 시 콤마 제거 후 숫자로 변환
+  const handleSubmit = () => {
+    const amount = Number(priceStr.replaceAll(",", ""));
+    if (!amount || amount <= 0) return;
+    onConfirm(amount); // 부모에서 다음 단계 처리
+  };
+
+  return (
+    <div
+      className="fixed inset-0 bg-gray-600 bg-opacity-50 flex justify-center items-center z-50"
+      onClick={handleOverlayClick}
+    >
+      <div className="bg-white p-8 rounded-lg shadow-lg w-full max-w-lg relative animate-fade-in">
+        <button
+          onClick={onClose}
+          className="absolute top-4 right-4 text-gray-500 hover:text-gray-700 text-3xl font-bold"
+        >
+          &times;
+        </button>
+
+        <h1 className="text-3xl font-bold mb-1 text-center">출금하기</h1>
+        <h3 className="text-md text-gray-500 mb-6 text-center">
+          (가격단위:원)
+        </h3>
+        <hr className="mb-6" />
+
+        <div className="mb-4">
+          <div className="flex justify-between items-center">
+            <div className="flex gap-2 items-center text-gray-600">
+              <span>실명 계좌</span>
+              <CiCircleQuestion />
+            </div>
+            <span className="text-gray-500">100012641093</span>
+          </div>
+          <div className="flex justify-between items-center mt-2">
+            <div className="flex gap-2 items-center text-gray-600">
+              <span>출금 가능</span>
+              <CiCircleQuestion />
+            </div>
+            <span className="text-gray-500">12,000,000</span>
+          </div>
+
+          <input
+            type="text" // 콤마 표기를 위해 text 사용
+            inputMode="numeric" // 모바일 숫자 키패드
+            pattern="[0-9]*" // 숫자만
+            value={priceStr}
+            onChange={handlePriceChange}
+            className="mt-8 w-full border rounded-lg px-4 py-2"
+            placeholder="출금하실 금액을 입력해주세요"
+          />
+        </div>
+
+        <div className="flex justify-center space-x-3 mt-6">
+          <button
+            onClick={onClose}
+            className="bg-gray-300 text-gray-800 py-2 px-4 rounded-md hover:bg-gray-400 transition-colors font-semibold"
+          >
+            취소
+          </button>
+          <button
+            onClick={handleSubmit}
+            className="bg-red-300 text-white py-2 px-4 rounded-md hover:bg-red-500 transition-colors font-semibold"
+          >
+            출금신청
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default AssetWithdrawModal;

--- a/src/pages/investment/InvestmentComponent/InvestmentModal.jsx
+++ b/src/pages/investment/InvestmentComponent/InvestmentModal.jsx
@@ -1,163 +1,186 @@
-import React, {useEffect, useState} from 'react';
+import React, { useEffect, useState } from "react";
 import useScrollLock from "../../../component/ScrollLock";
 
-function InvestmentModal({ isOpen, onClose, minInvestment, imageUrl, title, summary, author, tokenPrice }) {
+function InvestmentModal({
+  isOpen,
+  onClose,
+  minInvestment,
+  imageUrl,
+  title,
+  summary,
+  author,
+  tokenPrice,
+}) {
+  const [hasConfirmed, setHasConfirmed] = useState(false);
+  const [investmentAmount, setInvestmentAmount] = useState(minInvestment || 0);
 
-    const [hasConfirmed, setHasConfirmed] = useState(false);
-    const [investmentAmount, setInvestmentAmount] = useState(minInvestment || 0);
+  //스크롤 방지
+  useScrollLock(isOpen);
 
-    //스크롤 방지
-    useScrollLock(isOpen);
+  if (!isOpen) return null;
 
-    if (!isOpen) return null;
+  // 모달 외부 클릭 시 닫히도록 설정
+  const handleOverlayClick = (e) => {
+    if (e.target === e.currentTarget) {
+      onClose();
+    }
+  };
 
-    // 모달 외부 클릭 시 닫히도록 설정
-    const handleOverlayClick = (e) => {
-        if (e.target === e.currentTarget) {
-            onClose();
-        }
-    };
+  const handleConfirmChange = (e) => {
+    setHasConfirmed(e.target.checked);
+  };
 
-    const handleConfirmChange = (e) => {
-        setHasConfirmed(e.target.checked);
-    };
+  const handleAmountChange = (e) => {
+    const value = e.target.value;
+    if (value === "") {
+      setInvestmentAmount("");
+    } else {
+      const numValue = parseFloat(value);
+      if (!isNaN(numValue)) {
+        setInvestmentAmount(numValue);
+      }
+    }
+  };
 
-    const handleAmountChange = (e) => {
-        const value = e.target.value;
-        if (value === '') {
-            setInvestmentAmount('');
-        } else {
-            const numValue = parseFloat(value);
-            if (!isNaN(numValue)) {
-                setInvestmentAmount(numValue);
-            }
-        }
-    };
+  // 실제 투자 신청 버튼 클릭
+  const handleApplyInvestment = () => {
+    if (!hasConfirmed) {
+      alert("투자에 대한 정보를 확인했음을 체크해 주세요.");
+      return;
+    }
+    if (investmentAmount < minInvestment) {
+      alert(`최소 투자 금액은 ${minInvestment.toLocaleString()}원입니다.`);
+      return;
+    }
 
-    // 실제 투자 신청 버튼 클릭
-    const handleApplyInvestment = () => {
-        if (!hasConfirmed) {
-            alert('투자에 대한 정보를 확인했음을 체크해 주세요.');
-            return;
-        }
-        if (investmentAmount < minInvestment) {
-            alert(`최소 투자 금액은 ${minInvestment.toLocaleString()}원입니다.`);
-            return;
-        }
+    const expectedTokens = tokenPrice > 0 ? investmentAmount / tokenPrice : 0;
 
-        const expectedTokens = tokenPrice > 0 ? (investmentAmount / tokenPrice) : 0;
-
-        alert(`
+    alert(`
             투자 신청 완료!
             프로젝트: ${title}
             금액: ${investmentAmount.toLocaleString()}원
             예상 토큰 수량: ${expectedTokens.toFixed(2)}개
         `);
-        onClose();
-    };
+    onClose();
+  };
 
-    const expectedTokens = tokenPrice > 0 ? (investmentAmount / tokenPrice) : 0; // 예상 토큰 수량 계산
+  const expectedTokens = tokenPrice > 0 ? investmentAmount / tokenPrice : 0; // 예상 토큰 수량 계산
 
-    return (
-        <div
-            className="fixed inset-0 bg-gray-600 bg-opacity-50 flex justify-center items-center z-50"
-            onClick={handleOverlayClick}
+  return (
+    <div
+      className="fixed inset-0 bg-gray-600 bg-opacity-50 flex justify-center items-center z-50"
+      onClick={handleOverlayClick}
+    >
+      <div className="bg-white p-8 rounded-lg shadow-lg w-full max-w-lg relative animate-fade-in">
+        <button
+          onClick={onClose}
+          className="absolute top-4 right-4 text-gray-500 hover:text-gray-700 text-3xl font-bold"
         >
-            <div className="bg-white p-8 rounded-lg shadow-lg w-full max-w-lg relative animate-fade-in">
-                <button
-                    onClick={onClose}
-                    className="absolute top-4 right-4 text-gray-500 hover:text-gray-700 text-3xl font-bold"
-                >
-                    &times;
-                </button>
+          &times;
+        </button>
 
-                <h2 className="text-2xl font-bold mb-4 text-center">투자 신청하기</h2>
-                <hr className="mb-6"/>
+        <h2 className="text-2xl font-bold mb-4 text-center">투자 신청하기</h2>
+        <hr className="mb-6" />
 
-                <div className="flex items-start gap-4 mb-6">
-                    {imageUrl && (
-                        <div className="flex-shrink-0 w-28 h-28">
-                            <img
-                                src={imageUrl}
-                                alt="프로젝트 이미지"
-                                className="w-full h-full object-cover rounded-md"
-                            />
-                        </div>
-                    )}
-                    <div className="flex flex-col flex-grow">
-                        <h3 className="text-xl font-semibold mb-1">{title}</h3>
-                        <p className="text-gray-600 text-sm mb-2">작성자: {author}</p>
-                        <p className="text-gray-700 text-sm overflow-hidden text-ellipsis line-clamp-3">{summary}</p>
-                    </div>
-                </div>
-                <hr className="mb-6"/>
-
-                <div className="mb-6">
-                    <div className="flex justify-between items-center text-lg font-bold mb-2">
-                        <span className="text-gray-800">토큰 하나 가격:</span>
-                        <span className="text-red-600">{tokenPrice.toLocaleString()}원</span>
-                    </div>
-                    <div className="flex justify-between items-center text-base mb-4">
-                        <span className="text-gray-700">최소 투자 금액:</span>
-                        <span className="text-blue-600 font-semibold">{minInvestment.toLocaleString()}원</span>
-                    </div>
-
-                    <div className="flex items-center mt-4 p-3 bg-gray-100 rounded-md">
-                        <input
-                            type="checkbox"
-                            id="hasConfirmed"
-                            checked={hasConfirmed}
-                            onChange={handleConfirmChange}
-                            className="mr-2 h-5 w-5 text-red-600 rounded focus:ring-red-500"
-                        />
-                        <label htmlFor="hasConfirmed" className="text-gray-800 font-semibold cursor-pointer">
-                            해당 프로젝트의 정보를 확인했습니다.
-                        </label>
-                    </div>
-                </div>
-
-                <div className="mb-6">
-                    <label htmlFor="investmentAmount" className="block text-gray-700 text-base font-bold mb-2">
-                        투자 금액:
-                    </label>
-                    <input
-                        type="number"
-                        id="investmentAmount"
-                        name="investmentAmount"
-                        value={investmentAmount}
-                        onChange={handleAmountChange}
-                        placeholder="투자 금액을 입력하세요 (원)"
-                        className="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline"
-                        min={minInvestment}
-                    />
-                    <p className="text-right text-sm text-gray-500 mt-2">
-                        예상 토큰 수량: <span className="font-semibold">{expectedTokens.toFixed(2)}개</span>
-                    </p>
-                </div>
-
-                <div className="flex justify-end space-x-3 mt-6">
-                    <button
-                        onClick={onClose}
-                        className="bg-gray-300 text-gray-800 py-2 px-4 rounded-md hover:bg-gray-400 transition-colors font-semibold"
-                    >
-                        취소
-                    </button>
-                    <button
-                        onClick={handleApplyInvestment}
-                        className={`
-                            py-2 px-4 rounded-md font-semibold transition-colors
-                            ${hasConfirmed && investmentAmount >= minInvestment
-                            ? 'bg-red-500 text-white hover:bg-red-600'
-                            : 'bg-red-300 text-gray-100 cursor-not-allowed'}
-                        `}
-                        disabled={!hasConfirmed || investmentAmount < minInvestment}
-                    >
-                        신청하기
-                    </button>
-                </div>
+        <div className="flex items-start gap-4 mb-6">
+          {imageUrl && (
+            <div className="flex-shrink-0 w-28 h-28">
+              <img
+                src={imageUrl}
+                alt="프로젝트 이미지"
+                className="w-full h-full object-cover rounded-md"
+              />
             </div>
+          )}
+          <div className="flex flex-col flex-grow">
+            <h3 className="text-xl font-semibold mb-1">{title}</h3>
+            <p className="text-gray-600 text-sm mb-2">작성자: {author}</p>
+            <p className="text-gray-700 text-sm overflow-hidden text-ellipsis line-clamp-3">
+              {summary}
+            </p>
+          </div>
         </div>
-    );
+        <hr className="mb-6" />
+
+        <div className="mb-6">
+          <div className="flex justify-between items-center text-lg font-bold mb-2">
+            <span className="text-gray-800">토큰 하나 가격:</span>
+            <span className="text-red-600">
+              {tokenPrice.toLocaleString()}원
+            </span>
+          </div>
+          <div className="flex justify-between items-center text-base mb-4">
+            <span className="text-gray-700">최소 투자 금액:</span>
+            <span className="text-blue-600 font-semibold">
+              {minInvestment.toLocaleString()}원
+            </span>
+          </div>
+
+          <div className="flex items-center mt-4 p-3 bg-gray-100 rounded-md">
+            <input
+              type="checkbox"
+              id="hasConfirmed"
+              checked={hasConfirmed}
+              onChange={handleConfirmChange}
+              className="mr-2 h-5 w-5 text-red-600 rounded focus:ring-red-500"
+            />
+            <label
+              htmlFor="hasConfirmed"
+              className="text-gray-800 font-semibold cursor-pointer"
+            >
+              해당 프로젝트의 정보를 확인했습니다.
+            </label>
+          </div>
+        </div>
+
+        <div className="mb-6">
+          <label
+            htmlFor="investmentAmount"
+            className="block text-gray-700 text-base font-bold mb-2"
+          >
+            투자 금액:
+          </label>
+          <input
+            type="number"
+            id="investmentAmount"
+            name="investmentAmount"
+            value={investmentAmount}
+            onChange={handleAmountChange}
+            placeholder="투자 금액을 입력하세요 (원)"
+            className="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline"
+            min={minInvestment}
+          />
+          <p className="text-right text-sm text-gray-500 mt-2">
+            예상 토큰 수량:{" "}
+            <span className="font-semibold">{expectedTokens.toFixed(2)}개</span>
+          </p>
+        </div>
+
+        <div className="flex justify-end space-x-3 mt-6">
+          <button
+            onClick={onClose}
+            className="bg-gray-300 text-gray-800 py-2 px-4 rounded-md hover:bg-gray-400 transition-colors font-semibold"
+          >
+            취소
+          </button>
+          <button
+            onClick={handleApplyInvestment}
+            className={`
+                            py-2 px-4 rounded-md font-semibold transition-colors
+                            ${
+                              hasConfirmed && investmentAmount >= minInvestment
+                                ? "bg-red-500 text-white hover:bg-red-600"
+                                : "bg-red-300 text-gray-100 cursor-not-allowed"
+                            }
+                        `}
+            disabled={!hasConfirmed || investmentAmount < minInvestment}
+          >
+            신청하기
+          </button>
+        </div>
+      </div>
+    </div>
+  );
 }
 
 export default InvestmentModal;


### PR DESCRIPTION
## 이슈
- Resolve #51 AssetPage 화면 구현


## 📁 작업 파일
src/pages/asset/**


## 📝작업 내용
- 내용
FIGMA로 디자인 했던 Asset화면을 모두 코드로 구현했습니다.
 - 세부내용
Modal 화면 추가 및 프로세스 확립

## 🖼️작업 완
<img width="1267" height="707" alt="Screenshot 2025-08-12 at 14 49 55" src="https://github.com/user-attachments/assets/d0668fc5-d445-49c7-a24f-c7b53d6014d2" />
료 이미지 (완성된 페이지 전과 후 비교 및 코드 사진)
<img width="1267" height="707" alt="Screenshot 2025-08-12 at 14 50 06" src="https://github.com/user-attachments/assets/6ec68d01-e18f-4
<img width="1267" height="707" alt="Screenshot 2025-08-12 at 14 50 15" src="https://github.com/user-attachments/assets/5ff5f8cc-85f5-4b8f-bb3f-50db7e1d5be1" />
dc0-b6f1-a86249973ce6" />


## 🚨수정 필요 내용
- 계좌 연동 화면
- User가 처음 계좌를 사용할때랑 아닐때를 구분할 수 있는 화면 구현
