### PR TITLE
[feature/frontend-54/market] PR Market Page의 모달 화면 및 탭 화면 구현

### DIFF
--- a/src/pages/investment/InvestmentComponent/InvestmentDescription.jsx
+++ b/src/pages/investment/InvestmentComponent/InvestmentDescription.jsx
@@ -1,21 +1,27 @@
-import React from 'react';
+import React from "react";
 
 function InvestmentDescription({ imageUrl, summary, description }) {
-    return (
-        <div className="bg-white p-6 rounded-lg mt-10">
-            <h2 className="text-2xl font-bold mb-4">프로젝트 상세</h2>
+  return (
+    <div className="bg-white py-6 rounded-lg mt-10">
+      <h2 className="text-2xl font-bold mb-4">프로젝트 상세</h2>
 
-            {imageUrl && (
-                <img src={imageUrl} alt="프로젝트 이미지" className="w-full rounded-lg mb-6 max-h-96 object-contain"/>
-            )}
+      {imageUrl && (
+        <img
+          src={imageUrl}
+          alt="프로젝트 이미지"
+          className="w-full rounded-lg mb-6 max-h-96 object-contain"
+        />
+      )}
 
-            <h3 className="text-xl font-semibold mb-3">프로젝트 요약</h3>
-            <p className="text-gray-700 leading-relaxed mb-6">{summary}</p>
+      <h3 className="text-xl font-semibold mb-3">프로젝트 요약</h3>
+      <p className="text-gray-700 leading-relaxed mb-6">{summary}</p>
 
-            <h3 className="text-xl font-semibold mb-3">상세 설명</h3>
-            <p className="text-gray-700 leading-relaxed whitespace-pre-wrap">{description}</p>
-        </div>
-    );
+      <h3 className="text-xl font-semibold mb-3">상세 설명</h3>
+      <p className="text-gray-700 leading-relaxed whitespace-pre-wrap">
+        {description}
+      </p>
+    </div>
+  );
 }
 
 export default InvestmentDescription;

--- a/src/pages/investment/InvestmentComponent/InvestmentFiles.jsx
+++ b/src/pages/investment/InvestmentComponent/InvestmentFiles.jsx
@@ -1,35 +1,46 @@
-import React from 'react';
-import { FaFilePdf, FaFileExcel, FaDownload } from 'react-icons/fa'; // 파일 타입에 따른 아이콘
+import React from "react";
+import { FaFilePdf, FaFileExcel, FaDownload } from "react-icons/fa"; // 파일 타입에 따른 아이콘
 
 function InvestmentFiles({ files }) {
-    const getFileIcon = (fileName) => {
-        if (fileName.endsWith('.pdf')) return <FaFilePdf className="text-red-500" />;
-        if (fileName.endsWith('.xlsx') || fileName.endsWith('.xls')) return <FaFileExcel className="text-green-500" />;
-        return <FaDownload className="text-gray-500" />; // 기본 아이콘
-    };
+  const getFileIcon = (fileName) => {
+    if (fileName.endsWith(".pdf"))
+      return <FaFilePdf className="text-red-500" />;
+    if (fileName.endsWith(".xlsx") || fileName.endsWith(".xls"))
+      return <FaFileExcel className="text-green-500" />;
+    return <FaDownload className="text-gray-500" />; // 기본 아이콘
+  };
 
-    return (
-        <div className="bg-white p-6 rounded-lg mt-10">
-            <h2 className="text-2xl font-bold mb-4">첨부 파일</h2>
-            {files && files.length > 0 ? (
-                <ul>
-                    {files.map((file, index) => (
-                        <li key={index} className="flex items-center justify-between py-2 border-b last:border-b-0">
-                            <div className="flex items-center">
-                                <span className="mr-3 text-lg">{getFileIcon(file.name)}</span>
-                                <span className="text-blue-600 hover:underline">{file.name}</span>
-                            </div>
-                            <a href={file.url} download={file.name} className="bg-blue-500 text-white px-3 py-1 rounded-full text-sm hover:bg-blue-600 flex items-center">
-                                <FaDownload className="inline-block mr-1" /> 다운로드
-                            </a>
-                        </li>
-                    ))}
-                </ul>
-            ) : (
-                <p className="text-gray-600">첨부 파일이 없습니다.</p>
-            )}
-        </div>
-    );
+  return (
+    <div className="bg-white rounded-lg mt-10">
+      <h2 className="text-2xl font-bold mb-4">첨부 파일</h2>
+      {files && files.length > 0 ? (
+        <ul>
+          {files.map((file, index) => (
+            <li
+              key={index}
+              className="flex items-center justify-between py-2 border-b last:border-b-0"
+            >
+              <div className="flex items-center">
+                <span className="mr-3 text-lg">{getFileIcon(file.name)}</span>
+                <span className="text-blue-600 hover:underline">
+                  {file.name}
+                </span>
+              </div>
+              <a
+                href={file.url}
+                download={file.name}
+                className="bg-blue-500 text-white px-3 py-1 rounded-full text-sm hover:bg-blue-600 flex items-center"
+              >
+                <FaDownload className="inline-block mr-1" /> 다운로드
+              </a>
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <p className="text-gray-600">첨부 파일이 없습니다.</p>
+      )}
+    </div>
+  );
 }
 
 export default InvestmentFiles;

--- a/src/pages/investment/InvestmentComponent/InvestmentProgress.jsx
+++ b/src/pages/investment/InvestmentComponent/InvestmentProgress.jsx
@@ -1,32 +1,48 @@
-import React from 'react';
+import React from "react";
 
-function InvestmentProgress({ currentAmount, minInvestment, targetAmount, progress }) {
-    const formatCurrency = (amount) => {
-        return new Intl.NumberFormat('ko-KR', { style: 'currency', currency: 'KRW' }).format(amount);
-    };
+function InvestmentProgress({
+  currentAmount,
+  minInvestment,
+  targetAmount,
+  progress,
+}) {
+  const formatCurrency = (amount) => {
+    return new Intl.NumberFormat("ko-KR", {
+      style: "currency",
+      currency: "KRW",
+    }).format(amount);
+  };
 
-    return (
-        <div className="bg-white p-6 rounded-lg mb-6">
-            <h2 className="text-2xl font-bold mb-4">투자 목표 및 진행</h2>
+  return (
+    <div className="bg-white py-6 rounded-lg mb-6">
+      <h2 className="text-2xl font-bold mb-4">투자 목표 및 진행</h2>
 
-            <div className="w-full bg-gray-200 rounded-full h-4 mb-3">
-                <div
-                    className="bg-red-500 h-4 rounded-full"
-                    style={{ width: `${progress}%` }}
-                ></div>
-            </div>
+      <div className="w-full bg-gray-200 rounded-full h-4 mb-3">
+        <div
+          className="bg-red-500 h-4 rounded-full"
+          style={{ width: `${progress}%` }}
+        ></div>
+      </div>
 
-            <div className="flex justify-between items-baseline mb-4">
-                <span className="text-xl font-bold text-red-500">{progress}%</span>
-                <span className="text-sm text-gray-500">목표: {formatCurrency(targetAmount)}</span>
-            </div>
+      <div className="flex justify-between items-baseline mb-4">
+        <span className="text-xl font-bold text-red-500">{progress}%</span>
+        <span className="text-sm text-gray-500">
+          목표: {formatCurrency(targetAmount)}
+        </span>
+      </div>
 
-            <div className="grid grid-cols-2 gap-4 text-sm text-gray-700">
-                <div>현재 유치 금액: <span className="font-semibold">{formatCurrency(currentAmount)}</span></div>
-                <div className="text-right">최소 투자 금액: <span className="font-semibold">{formatCurrency(minInvestment)}</span></div>
-            </div>
+      <div className="grid grid-cols-2 gap-4 text-sm text-gray-700">
+        <div>
+          현재 유치 금액:{" "}
+          <span className="font-semibold">{formatCurrency(currentAmount)}</span>
         </div>
-    );
+        <div className="text-right">
+          최소 투자 금액:{" "}
+          <span className="font-semibold">{formatCurrency(minInvestment)}</span>
+        </div>
+      </div>
+    </div>
+  );
 }
 
 export default InvestmentProgress;

--- a/src/pages/investment/InvestmentComponent/InvestmentSummary.jsx
+++ b/src/pages/investment/InvestmentComponent/InvestmentSummary.jsx
@@ -1,118 +1,167 @@
-import React, { useState } from 'react';
-import { FaShareAlt, FaRegStar, FaStar, FaFlag, FaRegMoneyBillAlt, FaMoneyBillAlt } from 'react-icons/fa';
-import { RiMoneyCnyBoxFill, RiMoneyCnyBoxLine } from 'react-icons/ri';
+import React, { useState } from "react";
+import {
+  FaShareAlt,
+  FaRegStar,
+  FaStar,
+  FaFlag,
+  FaRegMoneyBillAlt,
+  FaMoneyBillAlt,
+} from "react-icons/fa";
+import { RiMoneyCnyBoxFill, RiMoneyCnyBoxLine } from "react-icons/ri";
 import InvestmentModal from "./InvestmentModal";
-import ReportModal from './ReportModal';
+import ReportModal from "./ReportModal";
 
+function InvestmentSummary({
+  title,
+  projectNumber,
+  startDate,
+  endDate,
+  author,
+  isFavorite: initialIsFavorite,
+  isInvested,
+  minInvestment,
+  imageUrl,
+  summary,
+  tokenPrice,
+  reporterId,
+}) {
+  const [isFavorite, setIsFavorite] = useState(initialIsFavorite);
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [isReportModalOpen, setIsReportModalOpen] = useState(false);
 
-function InvestmentSummary({ title, projectNumber, startDate, endDate, author, isFavorite: initialIsFavorite, isInvested, minInvestment, imageUrl, summary, tokenPrice, reporterId }) {
-    const [isFavorite, setIsFavorite] = useState(initialIsFavorite);
-    const [isModalOpen, setIsModalOpen] = useState(false);
-    const [isReportModalOpen, setIsReportModalOpen] = useState(false);
+  // 공유하기, 즐겨찾기, 신고
+  const handleShare = () => {
+    alert("공유하기!");
+  };
+  const handleFavoriteToggle = () => {
+    setIsFavorite(!isFavorite);
+    alert(`즐겨찾기 ${isFavorite ? "해제" : "추가"}!`);
+  };
+  const handleReport = () => {
+    setIsReportModalOpen(true);
+  };
 
-    // 공유하기, 즐겨찾기, 신고
-    const handleShare = () => { alert('공유하기!'); };
-    const handleFavoriteToggle = () => {setIsFavorite(!isFavorite); alert(`즐겨찾기 ${isFavorite ? '해제' : '추가'}!`); };
-    const handleReport = () => { setIsReportModalOpen(true); };
+  const handleInvest = () => {
+    setIsModalOpen(true);
+  };
 
-    const handleInvest = () => {
-        setIsModalOpen(true);
-    };
+  const handleCancelInvestment = () => {
+    alert("투자를 취소합니다.");
 
-    const handleCancelInvestment = () => {
-        alert('투자를 취소합니다.');
+    window.location.reload();
+  };
 
-        window.location.reload();
-    };
+  //투자하기 모달 닫기
+  const closeModal = () => {
+    setIsModalOpen(false);
+  };
 
-    //투자하기 모달 닫기
-    const closeModal = () => {
-        setIsModalOpen(false);
-    };
+  //신고하기 모달 닫기
+  const closeReportModal = () => {
+    setIsReportModalOpen(false);
+  };
 
-    //신고하기 모달 닫기
-    const closeReportModal = () => {
-        setIsReportModalOpen(false);
-    };
+  const handleReportSubmit = (reportData) => {
+    console.log("신고 데이터:", reportData);
+  };
 
-    const handleReportSubmit = (reportData) => {
-        console.log('신고 데이터:', reportData);
-    };
+  return (
+    <div className="bg-white py-6 rounded-lg">
+      <h1 className="text-3xl font-bold mb-2">{title}</h1>
+      <p className="text-gray-600 mb-4">프로젝트 번호: {projectNumber}</p>
 
-    return (
-        <div className="bg-white p-6 rounded-lg">
-            <h1 className="text-3xl font-bold mb-2">{title}</h1>
-            <p className="text-gray-600 mb-4">프로젝트 번호: {projectNumber}</p>
-
-            <div className="flex justify-between items-start text-sm text-gray-500 mb-4">
-                <div>
-                    <span>기간: {startDate} ~ {endDate}</span>
-                    <span className="ml-4">작성자: {author}</span>
-                </div>
-
-                <div className="flex flex-col space-y-2">
-
-                    {/* 투자하기, 투자 취소 버튼 */}
-                    <div className="flex justify-end space-x-2">
-                        <button
-                            onClick={handleInvest}
-                            className="bg-red-500 text-white py-2 px-3 rounded-md hover:bg-red-600 transition-colors font-semibold flex items-center"
-                        >
-                            {isInvested ? <RiMoneyCnyBoxFill className="inline-block mr-1" /> : <RiMoneyCnyBoxLine className="inline-block mr-1" />}
-                            {isInvested ? '투자하기' : '투자하기'} {/*원래 추가투자하기였는데 일단 그냥 하나로 보이게 변경 해둠*/}
-                        </button>
-
-                        <button
-                            onClick={handleCancelInvestment}
-                            className={`
-                                border border-gray-300 py-2 px-3 rounded-md font-semibold flex items-center
-                                ${isInvested ? 'text-gray-700 hover:bg-gray-100' : 'text-gray-400 cursor-not-allowed bg-gray-100'}
-                            `}
-                            disabled={!isInvested}
-                        >
-                            <RiMoneyCnyBoxLine className="inline-block mr-1" /> 투자취소
-                        </button>
-                    </div>
-
-                    {/* 공유, 즐겨찾기, 신고 버튼 */}
-                    <div className="flex justify-end space-x-2">
-                        <button onClick={handleShare} className="text-blue-500 hover:text-blue-700 flex items-center">
-                            <FaShareAlt className="inline-block mr-1" /> 공유
-                        </button>
-
-                        <button onClick={handleFavoriteToggle} className="text-yellow-500 hover:text-yellow-700 flex items-center">
-                            {isFavorite ? <FaStar className="inline-block mr-1" /> : <FaRegStar className="inline-block mr-1" />} 즐겨찾기
-                        </button>
-
-                        <button onClick={handleReport} className="text-red-500 hover:text-red-700 flex items-center">
-                            <FaFlag className="inline-block mr-1" /> 신고
-                        </button>
-                    </div>
-
-                </div>
-            </div>
-            <hr className="my-4"/>
-
-            <InvestmentModal
-                isOpen={isModalOpen}
-                onClose={closeModal}
-                minInvestment={minInvestment}
-                imageUrl={imageUrl}
-                title={title}
-                summary={summary}
-                author={author}
-                tokenPrice={tokenPrice}
-            />
-
-            <ReportModal
-                isOpen={isReportModalOpen}
-                onClose={closeReportModal}
-                projectNumber={projectNumber} // prop으로 받은 projectNumber 전달
-                reporterId={reporterId}       // prop으로 받은 reporterId 전달
-                onSubmitReport={handleReportSubmit} // 신고 처리 함수 전달
-            />
+      <div className="flex justify-between items-start text-sm text-gray-500 mb-4">
+        <div>
+          <span>
+            기간: {startDate} ~ {endDate}
+          </span>
+          <span className="ml-4">작성자: {author}</span>
         </div>
-    );
+
+        <div className="flex flex-col space-y-2">
+          {/* 투자하기, 투자 취소 버튼 */}
+          <div className="flex justify-end space-x-2">
+            <button
+              onClick={handleInvest}
+              className="bg-red-500 text-white py-2 px-3 rounded-md hover:bg-red-600 transition-colors font-semibold flex items-center"
+            >
+              {isInvested ? (
+                <RiMoneyCnyBoxFill className="inline-block mr-1" />
+              ) : (
+                <RiMoneyCnyBoxLine className="inline-block mr-1" />
+              )}
+              {isInvested ? "투자하기" : "투자하기"}{" "}
+              {/*원래 추가투자하기였는데 일단 그냥 하나로 보이게 변경 해둠*/}
+            </button>
+
+            <button
+              onClick={handleCancelInvestment}
+              className={`
+                                border border-gray-300 py-2 px-3 rounded-md font-semibold flex items-center
+                                ${
+                                  isInvested
+                                    ? "text-gray-700 hover:bg-gray-100"
+                                    : "text-gray-400 cursor-not-allowed bg-gray-100"
+                                }
+                            `}
+              disabled={!isInvested}
+            >
+              <RiMoneyCnyBoxLine className="inline-block mr-1" /> 투자취소
+            </button>
+          </div>
+
+          {/* 공유, 즐겨찾기, 신고 버튼 */}
+          <div className="flex justify-end space-x-2">
+            <button
+              onClick={handleShare}
+              className="text-blue-500 hover:text-blue-700 flex items-center"
+            >
+              <FaShareAlt className="inline-block mr-1" /> 공유
+            </button>
+
+            <button
+              onClick={handleFavoriteToggle}
+              className="text-yellow-500 hover:text-yellow-700 flex items-center"
+            >
+              {isFavorite ? (
+                <FaStar className="inline-block mr-1" />
+              ) : (
+                <FaRegStar className="inline-block mr-1" />
+              )}{" "}
+              즐겨찾기
+            </button>
+
+            <button
+              onClick={handleReport}
+              className="text-red-500 hover:text-red-700 flex items-center"
+            >
+              <FaFlag className="inline-block mr-1" /> 신고
+            </button>
+          </div>
+        </div>
+      </div>
+      <hr className="my-4" />
+
+      <InvestmentModal
+        isOpen={isModalOpen}
+        onClose={closeModal}
+        minInvestment={minInvestment}
+        imageUrl={imageUrl}
+        title={title}
+        summary={summary}
+        author={author}
+        tokenPrice={tokenPrice}
+      />
+
+      <ReportModal
+        isOpen={isReportModalOpen}
+        onClose={closeReportModal}
+        projectNumber={projectNumber} // prop으로 받은 projectNumber 전달
+        reporterId={reporterId} // prop으로 받은 reporterId 전달
+        onSubmitReport={handleReportSubmit} // 신고 처리 함수 전달
+      />
+    </div>
+  );
 }
 
 export default InvestmentSummary;

--- a/src/pages/market/MarketDetail.jsx
+++ b/src/pages/market/MarketDetail.jsx
@@ -3,16 +3,28 @@ import InvestmentFiles from "../investment/InvestmentComponent/InvestmentFiles";
 import { useEffect, useState } from "react";
 import { FaChevronLeft } from "react-icons/fa";
 import SalesChart from "./SalesChart";
+import TradeHistory from "./TradeHistory";
+import MarketPurchaseModal from "./modals/MarketPurchaseModal";
+import MarketSellModal from "./modals/MarketSellModal";
 
 function MarketDetail() {
   const { id } = useParams();
 
-  // 예시 데이터 (실제 프로젝트에서는 API로 받아오세요)
+  const [isTradeModalOpen, setIsTradeModalOpen] = useState(false);
+  const [tradeType, setTradeType] = useState(null); // '구매' | '판매'
+
+  const [firstTab, setFirstTab] = useState(0); // 0=거래, 1=거래내역
+  const [secondTab, setSecondTab] = useState(0);
+  const navigate = useNavigate();
+
   const product = {
     id: id,
     name: `프로젝트명 ${id}`,
-    images: Array(10).fill(null), // 이미지 10개 (실제 이미지 url로 대체)
-    mainImage: null, // 실제 이미지 url로 대체
+    images: Array(10).fill(null),
+    description:
+      "This project focuses on developing a sustainable, eco-friendly housing community in a rapidly growing suburban area. The development will feature energy-efficient homes with solar panels, rainwater harvesting systems, and community gardens. Our commitment to sustainability extends to using locally sourced, recycled materials wherever possible, minimizing the environmental impact of construction. The community is designed to appeal to environmentally conscious families and individuals seeking a healthier, more sustainable lifestyle. The location offers convenient access to urban amenities while preserving a tranquil, natural setting. This investment offers a unique opportunity to support sustainable development while potentially benefiting from the increasing demand for eco-friendly housing.",
+
+    mainImage: null,
     files: [
       { name: "파일1.pdf", url: "/path/to/file1.pdf" },
       { name: "파일2.pdf", url: "/path/to/file2.pdf" },
@@ -20,14 +32,91 @@ function MarketDetail() {
     ],
   };
 
-  const [tab, setTab] = useState(0);
-  const [secondTab, setSecondTab] = useState(0);
-  const navigate = useNavigate();
+  const openPurchase = () => {
+    setTradeType("구매");
+    setIsTradeModalOpen(true);
+  };
+  const openSell = () => {
+    setTradeType("판매");
+    setIsTradeModalOpen(true);
+  };
+  const closeTradeModal = () => setIsTradeModalOpen(false);
+
+  const handlePurchaseConfirm = (payload) => {
+    // TODO: API 연동
+    console.log("구매 요청:", payload);
+    setIsTradeModalOpen(false);
+  };
+  const handleSellConfirm = (payload) => {
+    // TODO: API 연동
+    console.log("판매 요청:", payload);
+    setIsTradeModalOpen(false);
+  };
+
+  // 예시 체결 거래 데이터 (API 연동 시 교체)
+  const executedTrades = [
+    { qty: 1, price: 20324, time: "2024.05.12 12:10" },
+    { qty: 2, price: 20400, time: "2024.05.12 12:05" },
+    { qty: 1, price: 20210, time: "2024.05.12 11:59" },
+  ];
+  const buyBids = [
+    { qty: 3, price: 20100, time: "2024.05.12 12:12" },
+    { qty: 1, price: 20050, time: "2024.05.12 12:08" },
+  ];
+  const sellBids = [
+    { qty: 2, price: 20500, time: "2024.05.12 12:11" },
+    { qty: 1, price: 20620, time: "2024.05.12 12:07" },
+  ];
+
+  // 예시 거래내역 데이터 (API 연동 시 교체)
+  const historyData = [
+    {
+      id: 1,
+      tokenName: "토큰 이름",
+      side: "매수",
+      price: 300,
+      qty: 3,
+      amount: 900,
+      time: "2024-08-05 16:35",
+      status: "체결",
+    },
+    {
+      id: 2,
+      tokenName: "토큰 이름",
+      side: "매도",
+      price: 300,
+      qty: 3,
+      amount: 900,
+      time: "2024-08-05 16:35",
+      status: "체결",
+    },
+    {
+      id: 3,
+      tokenName: "토큰 이름",
+      side: "매수",
+      price: 310,
+      qty: 2,
+      amount: 620,
+      time: "2024-08-06 10:10",
+      status: "미체결",
+    },
+    {
+      id: 4,
+      tokenName: "토큰 이름",
+      side: "매수",
+      price: 310,
+      qty: 2,
+      amount: 620,
+      time: "2024-08-06 10:10",
+      status: "미체결",
+    },
+  ];
 
   return (
     <div className="flex w-full h-[calc(100vh+240px)] mb-24">
       {/* 왼쪽: 스크롤 가능 영역 */}
       <div className="flex-1 overflow-y-auto p-4 pr-8 scrollbar-hide">
+        {/* ...existing code... 왼쪽 내용 그대로 유지 ... */}
         <div className="flex flex-row items-center">
           <button
             onClick={() => navigate("/market")}
@@ -43,7 +132,6 @@ function MarketDetail() {
         >
           썸네일 이미지
         </div>
-        {/* 썸네일 그리드 */}
         <div className="grid grid-cols-5 gap-4 mb-8 ">
           {product.images.map((img, idx) => (
             <div
@@ -55,158 +143,230 @@ function MarketDetail() {
           ))}
         </div>
         <h1 className="text-3xl font-bold mb-6">프로젝트 상세설명</h1>
-        <h3>프로젝트 현황</h3>
-        <p>
-          The project is currently in the construction phase, with all necessary
-          permits secured. The foundation has been laid, and framing is
-          underway. We anticipate completing the exterior shell by the end of Q2
-          2024.{" "}
-        </p>
-        <h3>프로젝트 상세설명</h3>
-        <p>
-          This project focuses on developing a sustainable, eco-friendly housing
-          community in a rapidly growing suburban area. The development will
-          feature energy-efficient homes with solar panels, rainwater harvesting
-          systems, and community gardens. Our commitment to sustainability
-          extends to using locally sourced, recycled materials wherever
-          possible, minimizing the environmental impact of construction. The
-          community is designed to appeal to environmentally conscious families
-          and individuals seeking a healthier, more sustainable lifestyle. The
-          location offers convenient access to urban amenities while preserving
-          a tranquil, natural setting. This investment offers a unique
-          opportunity to support sustainable development while potentially
-          benefiting from the increasing demand for eco-friendly housing.
-        </p>
-        <h3>프로젝트 파일</h3>
-        <p>
-          The project is currently in the construction phase, with all necessary
-          permits secured. The foundation has been laid, and framing is
-          underway. We anticipate completing the exterior shell by the end of Q2
-          2024.{" "}
-        </p>
+        <p>{product.description}</p>
         <InvestmentFiles files={product.files} />
       </div>
-      {/* 오른쪽: 고정 영역 */}
-      <div className="mt-8 w-[480px] min-w-[380px] h-full bg-white border-l px-4 pl-8 py-8 flex flex-col">
-        {/* 거래 정보 */}
-        <div>
-          {/* 탭 메뉴 */}
-          <div className="flex bg-gray-100 rounded-md mb-8 px-4 w-full max-w-xl mx-auto">
-            <button
-              className={`flex-1 text-center  text-md  transition ${
-                tab === 0 ? "text-red-500 font-bold" : "text-gray-400"
-              }`}
-              onClick={() => setTab(0)}
-            >
-              거래
-            </button>
-            <span className="text-gray-400">|</span>
-            <button
-              className={`flex-1 text-center text-md transition ${
-                tab === 1 ? "text-red-500 font-bold" : "text-gray-400"
-              }`}
-              onClick={() => setTab(1)}
-            >
-              거래내역
-            </button>
-          </div>
 
-          <div className="mb-4">
-            <div className="text-lg text-gray-700 font-bold">즉시 구매가</div>
-            <div className="text-3xl font-bold mb-4 mt-1">20,423 원</div>
-            {/* 가격 정보 */}
-            <div className="flex gap-6 text-left w-full">
-              <div className="w-full">
-                <div className="text-sm text-gray-400">최근 거래가</div>
-                <div className="text-gray-700 text-sm">42,000원</div>
-                <div className="text-green-600 text-sm font-bold">
-                  ▼3,000 (-6.7%)
+      {/* 오른쪽: 고정 영역 */}
+      <div className="overflow-y-auto scrollbar-hide mt-8 w-[480px] min-w-[380px] h-full bg-white border-l px-4 pl-8 py-8 flex flex-col">
+        {/* 탭 메뉴 */}
+        <div className="flex bg-gray-100 rounded-md mb-8 px-4 w-full max-w-xl mx-auto">
+          <button
+            className={`flex-1 text-center text-md transition ${
+              firstTab === 0 ? "text-red-500 font-bold" : "text-gray-400"
+            }`}
+            onClick={() => setFirstTab(0)}
+          >
+            거래
+          </button>
+          <span className="text-gray-400">|</span>
+          <button
+            className={`flex-1 text-center text-md transition ${
+              firstTab === 1 ? "text-red-500 font-bold" : "text-gray-400"
+            }`}
+            onClick={() => setFirstTab(1)}
+          >
+            거래내역
+          </button>
+        </div>
+
+        {/* 탭별 내용 */}
+        {firstTab === 0 ? (
+          <>
+            <div className="mb-4">
+              <div className="text-lg text-gray-700 font-bold">즉시 구매가</div>
+              <div className="text-3xl font-bold mb-4 mt-1">20,423 원</div>
+              <div className="flex gap-6 text-left w-full">
+                <div className="w-full">
+                  <div className="text-sm text-gray-400">최근 거래가</div>
+                  <div className="text-gray-700 text-sm">42,000원</div>
+                  <div className="text-green-600 text-sm font-bold">
+                    ▼3,000 (-6.7%)
+                  </div>
+                </div>
+                <div className="w-full border-l px-4">
+                  <div className="text-sm text-gray-400">발매가</div>
+                  <div className="text-gray-700 text-sm">74,900원</div>
+                </div>
+                <div className="w-full border-l px-4">
+                  <div className="text-sm text-gray-400">모델번호</div>
+                  <div className="text-gray-700 text-sm">205089-1LI</div>
+                </div>
+                <div className="w-full border-l px-4">
+                  <div className="text-sm text-gray-400">출시일</div>
+                  <div className="text-gray-700 text-sm">2024.01.04</div>
                 </div>
               </div>
-              <div className="w-full border-l px-4">
-                <div className="text-sm text-gray-400">발매가</div>
-                <div className="text-gray-700 text-sm">74,900원</div>
-              </div>
-              <div className="w-full border-l px-4">
-                <div className="text-sm text-gray-400">모델번호</div>
-                <div className="text-gray-700 text-sm">205089-1LI</div>
-              </div>
-              <div className="w-full border-l px-4">
-                <div className="text-sm text-gray-400">출시일</div>
-                <div className="text-gray-700 text-sm">2024.01.04</div>
-              </div>
             </div>
-          </div>
-          <div className="mt-8 flex gap-6 mb-6">
-            <button className="w-full bg-red-500 text-white font-bold rounded-lg px-8 py-3">
-              구매
-            </button>
-            <button className="w-full bg-red-100 text-red-500 font-bold rounded-lg px-8 py-3">
-              판매
-            </button>
-          </div>
-        </div>
-        {/* 시세 차트 (임시) */}
-        <div className="mb-6">
-          <div className="font-bold mb-2">시세</div>
-          <SalesChart />
-        </div>
-        {/* Second Tab */}
-        <div>
-          <div className="w-full flex bg-gray-100 p-1 rounded-md flex justify-around text-sm font-bold mb-2">
-            <button
-              className={`px-2 transition ${
-                secondTab === 0
-                  ? "text-red-500 border-red-500"
-                  : "text-gray-400 border-transparent"
-              }`}
-              onClick={() => setSecondTab(0)}
-            >
-              체결 거래
-            </button>
-            <span className="text-gray-300">|</span>
-            <button
-              className={`px-2  transition ${
-                secondTab === 1
-                  ? "text-red-500 border-red-500"
-                  : "text-gray-400 border-transparent"
-              }`}
-              onClick={() => setSecondTab(1)}
-            >
-              구매 입찰
-            </button>
-            <span className="text-gray-300">|</span>
-            <button
-              className={`px-2 transition ${
-                secondTab === 2
-                  ? "text-red-500 border-red-500"
-                  : "text-gray-400 border-transparent"
-              }`}
-              onClick={() => setSecondTab(2)}
-            >
-              판매 입찰
-            </button>
-          </div>
 
-          <table className="w-full text-sm border-b border-gray-200">
-            <thead>
-              <tr className="text-gray-500 text-left">
-                <th className="py-2 font-normal">토큰 수량</th>
-                <th className="font-normal">가격</th>
-                <th className="font-normal">거래일시</th>
-              </tr>
-            </thead>
-            <tbody>
-              {[1, 2, 3, 4].map((row) => (
-                <tr key={row} className="border-b border-gray-100">
-                  <td className="py-2 font-normal text-left">1</td>
-                  <td className="font-normal text-left">20,324</td>
-                  <td className="font-normal text-left">2024.05.12</td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
+            <div className="mt-8 flex gap-6 mb-6">
+              <button
+                onClick={openPurchase}
+                className="w-full bg-red-500 text-white font-bold rounded-lg px-8 py-3"
+              >
+                구매
+              </button>
+              <button
+                onClick={openSell}
+                className="w-full bg-red-100 text-red-500 font-bold rounded-lg px-8 py-3"
+              >
+                판매
+              </button>
+            </div>
+
+            <div className="mb-6">
+              <div className="font-bold mb-2">시세</div>
+              <SalesChart />
+            </div>
+
+            <div>
+              <div className="w-full flex bg-gray-100 p-1 rounded-md justify-around text-sm font-bold mb-2">
+                <button
+                  className={`px-2 transition ${
+                    secondTab === 0 ? "text-red-500" : "text-gray-400"
+                  }`}
+                  onClick={() => setSecondTab(0)}
+                >
+                  체결 거래
+                </button>
+                <span className="text-gray-300">|</span>
+                <button
+                  className={`px-2 transition ${
+                    secondTab === 1 ? "text-red-500" : "text-gray-400"
+                  }`}
+                  onClick={() => setSecondTab(1)}
+                >
+                  구매 입찰
+                </button>
+                <span className="text-gray-300">|</span>
+                <button
+                  className={`px-2 transition ${
+                    secondTab === 2 ? "text-red-500" : "text-gray-400"
+                  }`}
+                  onClick={() => setSecondTab(2)}
+                >
+                  판매 입찰
+                </button>
+              </div>
+
+              {/* secondTab에 따라 다른 테이블 렌더링 */}
+              {secondTab === 0 && (
+                <table className="w-full table-fixed text-sm border-b border-gray-200">
+                  <colgroup>
+                    <col className="w-1/3" />
+                    <col className="w-1/3" />
+                    <col className="w-1/3" />
+                  </colgroup>
+                  <thead>
+                    <tr className="text-gray-500 text-left">
+                      <th className="px-3 py-2 font-normal">토큰 수량</th>
+                      <th className="px-3 py-2 font-normal">체결가</th>
+                      <th className="px-3 py-2 font-normal">거래일시</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {executedTrades.map((r, i) => (
+                      <tr key={i} className="border-b border-gray-100">
+                        <td className="px-3 py-2 text-left">
+                          {r.qty.toLocaleString()}
+                        </td>
+                        <td className="px-3 py-2 text-left">
+                          {r.price.toLocaleString()}
+                        </td>
+                        <td className="px-3 py-2 text-left whitespace-nowrap">
+                          {r.time}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              )}
+              {secondTab === 1 && (
+                <table className="w-full table-fixed text-sm border-b border-gray-200">
+                  <colgroup>
+                    <col className="w-1/3" />
+                    <col className="w-1/3" />
+                    <col className="w-1/3" />
+                  </colgroup>
+                  <thead>
+                    <tr className="text-gray-500 text-left">
+                      <th className="px-3 py-2 font-normal">토큰 수량</th>
+                      <th className="px-3 py-2 font-normal">입찰가</th>
+                      <th className="px-3 py-2 font-normal">등록시간</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {buyBids.map((r, i) => (
+                      <tr key={i} className="border-b border-gray-100">
+                        <td className="px-3 py-2 text-left">
+                          {r.qty.toLocaleString()}
+                        </td>
+                        <td className="px-3 py-2 text-left text-red-600 font-semibold">
+                          {r.price.toLocaleString()}
+                        </td>
+                        <td className="px-3 py-2 text-left whitespace-nowrap">
+                          {r.time}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              )}
+              {secondTab === 2 && (
+                <table className="w-full table-fixed text-sm border-b border-gray-200">
+                  <colgroup>
+                    <col className="w-1/3" />
+                    <col className="w-1/3" />
+                    <col className="w-1/3" />
+                  </colgroup>
+                  <thead>
+                    <tr className="text-gray-500 text-left">
+                      <th className="px-3 py-2 font-normal">토큰 수량</th>
+                      <th className="px-3 py-2 font-normal">호가</th>
+                      <th className="px-3 py-2 font-normal">등록시간</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {sellBids.map((r, i) => (
+                      <tr key={i} className="border-b border-gray-100">
+                        <td className="px-3 py-2 text-left">
+                          {r.qty.toLocaleString()}
+                        </td>
+                        <td className="px-3 py-2 text-left text-blue-600 font-semibold">
+                          {r.price.toLocaleString()}
+                        </td>
+                        <td className="px-3 py-2 text-left whitespace-nowrap">
+                          {r.time}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              )}
+            </div>
+          </>
+        ) : (
+          <TradeHistory data={historyData} />
+        )}
+        {/* 모달 */}
+        {isTradeModalOpen && (
+          <>
+            {tradeType === "구매" && (
+              <MarketPurchaseModal
+                isOpen={isTradeModalOpen}
+                onClose={closeTradeModal}
+                onConfirm={handlePurchaseConfirm}
+              />
+            )}
+            {tradeType === "판매" && (
+              <MarketSellModal
+                isOpen={isTradeModalOpen}
+                onClose={closeTradeModal}
+                onConfirm={handleSellConfirm}
+              />
+            )}
+          </>
+        )}
       </div>
     </div>
   );

--- a/src/pages/market/SalesChart.jsx
+++ b/src/pages/market/SalesChart.jsx
@@ -61,7 +61,7 @@ const options = {
 
 function SalesChart() {
   return (
-    <div className="max-w-xl mx-auto bg-white rounded-lg ">
+    <div className="max-w-md mx-auto bg-white rounded-lg ">
       <Line data={data} options={options} />
     </div>
   );

--- a/src/pages/market/TradeHistory.jsx
+++ b/src/pages/market/TradeHistory.jsx
@@ -1,0 +1,85 @@
+import { useMemo, useState } from "react";
+
+export default function TradeHistory({ data = [] }) {
+  // 0=체결, 1=미체결
+  const [historyTab, setHistoryTab] = useState(0);
+
+  const filtered = useMemo(() => {
+    const status = historyTab === 0 ? "체결" : "미체결";
+    return data.filter((d) => d.status === status);
+  }, [data, historyTab]);
+
+  return (
+    <div className="w-full">
+      {/* 상단 탭 */}
+      <div className="flex gap-4 mb-4">
+        <button
+          className={`px-4 py-1 rounded-xl border transition ${
+            historyTab === 0
+              ? "border-red-400 text-red-500 font-bold"
+              : "border-gray-300 text-gray-500"
+          }`}
+          onClick={() => setHistoryTab(0)}
+        >
+          체결
+        </button>
+        <button
+          className={`px-4 py-1 rounded-xl border transition ${
+            historyTab === 1
+              ? "border-red-400 text-red-500 font-bold"
+              : "border-gray-300 text-gray-500"
+          }`}
+          onClick={() => setHistoryTab(1)}
+        >
+          미체결
+        </button>
+      </div>
+
+      {/* 총 건수 */}
+      <div className="text-gray-400 font-bold mb-2">총 {filtered.length}건</div>
+      <hr className="mb-4" />
+
+      {/* 카드 리스트 */}
+      <div className="space-y-4">
+        {filtered.map((item) => (
+          <div
+            key={item.id}
+            className="rounded-2xl border border-gray-300 px-6 py-5"
+          >
+            <div className="flex items-start justify-between">
+              <div>
+                <div className="text-lg font-bold">토큰 이름</div>
+                <div className="text-xs text-gray-400 mt-1">{item.time}</div>
+              </div>
+              <div
+                className={`text-lg font-extrabold ${
+                  item.side === "매수" ? "text-red-500" : "text-blue-600"
+                }`}
+              >
+                {item.side}
+              </div>
+            </div>
+
+            <div className="grid grid-cols-2 mt-6 gap-y-2">
+              <div className="text-gray-500">체결가격</div>
+              <div className="text-right">{item.price.toLocaleString()}</div>
+
+              <div className="text-gray-500">체결수량</div>
+              <div className="text-right">{item.qty.toLocaleString()}</div>
+
+              <div className="text-gray-500">체결금액</div>
+              <div className="text-right">
+                {(item.amount ?? item.price * item.qty).toLocaleString()}
+              </div>
+            </div>
+          </div>
+        ))}
+        {filtered.length === 0 && (
+          <div className="text-center text-gray-400 py-10">
+            표시할 내역이 없습니다.
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/pages/market/modals/MarketPurchaseModal.jsx
+++ b/src/pages/market/modals/MarketPurchaseModal.jsx
@@ -1,0 +1,108 @@
+import { useMemo, useState } from "react";
+import useScrollLock from "../../../component/ScrollLock";
+import SalesChart from "../SalesChart";
+import { toast } from "react-toastify";
+
+export default function MarketPurchaseModal({ isOpen, onClose, onConfirm }) {
+  useScrollLock(isOpen);
+  const [priceStr, setPriceStr] = useState("");
+  const [qtyStr, setQtyStr] = useState("");
+
+  // Hook들은 조건부 return 위에
+  const price = useMemo(
+    () => Number((priceStr || "0").replaceAll(",", "")),
+    [priceStr]
+  );
+  const qty = useMemo(
+    () => Number((qtyStr || "0").replaceAll(",", "")),
+    [qtyStr]
+  );
+  const total = useMemo(() => price * qty, [price, qty]);
+
+  if (!isOpen) return null;
+
+  const format = (digits) => digits.replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+  const onlyDigits = (v) => v.replace(/[^\d]/g, "");
+
+  const handlePriceChange = (e) => {
+    const d = onlyDigits(e.target.value);
+    setPriceStr(d ? format(d) : "");
+  };
+  const handleQtyChange = (e) => {
+    const d = onlyDigits(e.target.value);
+    setQtyStr(d ? format(d) : "");
+  };
+
+  const submit = () => {
+    if (!price || !qty) return;
+    onConfirm?.({ price, qty, total });
+    toast.success(`구매 요청이 완료되었습니다.`, {
+      style: { backgroundColor: "#fff", color: "#111" },
+      progressStyle: { backgroundColor: "#ef4444" },
+    });
+  };
+
+  const handleOverlayClick = (e) => {
+    if (e.target === e.currentTarget) onClose?.();
+  };
+
+  return (
+    <div
+      className="fixed inset-0 bg-black/50 flex items-center justify-center z-50"
+      onClick={handleOverlayClick}
+    >
+      <div className="bg-white rounded-lg shadow-lg w-full max-w-xl p-6 relative flex-col justify-center align-center">
+        <button
+          className="absolute right-4 top-3 text-2xl text-gray-500 hover:text-gray-700"
+          onClick={onClose}
+        >
+          &times;
+        </button>
+
+        <h2 className="text-2xl font-bold text-center mb-1">구매하기</h2>
+        <p className="text-center text-gray-500 mb-6">(가격 단위: 원)</p>
+        <SalesChart />
+
+        <label className="mt-6 block text-sm text-gray-500 mb-1">
+          구매 가격
+        </label>
+        <input
+          type="text"
+          inputMode="numeric"
+          pattern="[0-9]*"
+          value={priceStr}
+          onChange={handlePriceChange}
+          className="w-full border rounded-md px-3 py-2 mb-4"
+          placeholder="가격을 입력하세요"
+        />
+
+        <label className="block text-sm text-gray-500 mb-1">구매 수량</label>
+        <input
+          type="text"
+          inputMode="numeric"
+          pattern="[0-9]*"
+          value={qtyStr}
+          onChange={handleQtyChange}
+          className="w-full border rounded-md px-3 py-2 mb-4"
+          placeholder="수량을 입력하세요"
+        />
+
+        <label className="block text-sm text-gray-500 mb-1">총 가격</label>
+        <input
+          value={total ? total.toLocaleString() : ""}
+          readOnly
+          className="w-full border rounded-md px-3 py-2 bg-gray-100 mb-6"
+        />
+
+        <div className="flex justify-center gap-2">
+          <button
+            onClick={submit}
+            className="w-full px-4 py-2 rounded-md bg-red-500 text-white hover:bg-red-600"
+          >
+            구매입찰
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/market/modals/MarketSellModal.jsx
+++ b/src/pages/market/modals/MarketSellModal.jsx
@@ -1,0 +1,105 @@
+import { useMemo, useState } from "react";
+import useScrollLock from "../../../component/ScrollLock";
+import SalesChart from "../SalesChart";
+import { toast } from "react-toastify";
+
+export default function MarketSellModal({ isOpen, onClose, onConfirm }) {
+  useScrollLock(isOpen);
+  const [priceStr, setPriceStr] = useState("");
+  const [qtyStr, setQtyStr] = useState("");
+  // Hook들은 조건부 return 위에
+  const price = useMemo(
+    () => Number((priceStr || "0").replaceAll(",", "")),
+    [priceStr]
+  );
+  const qty = useMemo(
+    () => Number((qtyStr || "0").replaceAll(",", "")),
+    [qtyStr]
+  );
+  const total = useMemo(() => price * qty, [price, qty]);
+  if (!isOpen) return null;
+
+  const format = (digits) => digits.replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+  const onlyDigits = (v) => v.replace(/[^\d]/g, "");
+
+  const handlePriceChange = (e) => {
+    const d = onlyDigits(e.target.value);
+    setPriceStr(d ? format(d) : "");
+  };
+  const handleQtyChange = (e) => {
+    const d = onlyDigits(e.target.value);
+    setQtyStr(d ? format(d) : "");
+  };
+
+  const submit = () => {
+    if (!price || !qty) return;
+    onConfirm?.({ price, qty, total });
+    toast.success(`판매 요청이 완료되었습니다.`, {
+      style: { backgroundColor: "#fff", color: "#111" },
+      progressStyle: { backgroundColor: "#ef4444" },
+    });
+  };
+
+  const handleOverlayClick = (e) => {
+    if (e.target === e.currentTarget) onClose?.();
+  };
+
+  return (
+    <div
+      className="fixed inset-0 bg-black/50 flex items-center justify-center z-50"
+      onClick={handleOverlayClick}
+    >
+      <div className="bg-white rounded-lg shadow-lg  w-full max-w-xl p-6 relative">
+        <button
+          className="absolute right-4 top-3 text-2xl text-gray-500 hover:text-gray-700"
+          onClick={onClose}
+        >
+          &times;
+        </button>
+
+        <h2 className="text-2xl font-bold text-center mb-1">판매하기</h2>
+        <p className="text-center text-gray-500 mb-6">(가격 단위: 원)</p>
+        <SalesChart />
+
+        <label className="mt-4 block text-sm text-gray-500 mb-1">
+          판매 가격
+        </label>
+        <input
+          type="text"
+          inputMode="numeric"
+          pattern="[0-9]*"
+          value={priceStr}
+          onChange={handlePriceChange}
+          className="w-full border rounded-md px-3 py-2 mb-4"
+          placeholder="가격을 입력하세요"
+        />
+
+        <label className="block text-sm text-gray-500 mb-1">판매 수량</label>
+        <input
+          type="text"
+          inputMode="numeric"
+          pattern="[0-9]*"
+          value={qtyStr}
+          onChange={handleQtyChange}
+          className="w-full border rounded-md px-3 py-2 mb-4"
+          placeholder="수량을 입력하세요"
+        />
+
+        <label className="block text-sm text-gray-500 mb-1">총 금액</label>
+        <input
+          value={total ? total.toLocaleString() : ""}
+          readOnly
+          className="w-full border rounded-md px-3 py-2 bg-gray-100 mb-6"
+        />
+        <div className="mt-4 flex justify-center gap-2">
+          <button
+            onClick={submit}
+            className="w-full px-4 py-2 rounded-md bg-red-500 text-white hover:bg-red-600"
+          >
+            판매입찰
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## 이슈
- Resolve #53 Market Page의 모달 화면 및 탭 화면 구현


## 📁 작업 파일
src/pages/market


## 📝작업 내용
- 내용
기존에 생성했던 Market화면의 탭 화면과 구매,판매 모달화면을 구현했습니다.
  - 세부내용
Modal화면 그리고 State를 활용한 탭 화면 구현

## 🖼️작업 완료 이미지 (완성된 페이지 전과 후 비교 및 코드 사진)
<img width="1280" height="737" alt="Screenshot 2025-08-12 at 16 55 17" src="https://github.com/user-attachments/assets/b0d12a50-7b39-4300-9c1d-cabfff9a8c7b" />
<img width="1280" height="737" alt="Screenshot 2025-08-12 at 16 55 29" src="https://github.com/user-attachments/assets/9b1e8bc7-f1ca-4c1a-904e-b6b01666d57c" />
<img width="1280" height="737" alt="Screenshot 2025-08-12 at 16 55 44" src="https://github.com/user-attachments/assets/842a9865-b92d-4814-a685-3c2bf078f8b8" />


## 🚨수정 필요 내용
- API 연동 후 실제 데이터 삽입 필요